### PR TITLE
clamp the target frame rate setting.

### DIFF
--- a/Assets/Scripts/System/SettingsSystem.cs
+++ b/Assets/Scripts/System/SettingsSystem.cs
@@ -258,7 +258,7 @@ namespace Assets.Scripts.System
             TestString = new StringUserSetting(this, "Test text", "Hello world!");
             userSettings.Add(TestString);
 
-            applicationTargetFramerate = new IntUserSetting(this, "applicationTargetFramerate", -1);
+            applicationTargetFramerate = new IntClampedUserSetting(this, "applicationTargetFramerate", 120, 5, 1000);
             userSettings.Add(applicationTargetFramerate);
 
             ShownSettings.Add("User Settings", userSettings);
@@ -289,12 +289,12 @@ namespace Assets.Scripts.System
 
         public Dictionary<string, List<ISetting>> ShownSettings = new Dictionary<string, List<ISetting>>();
 
-        public FloatUserSetting uiScalingFactor;
-        public FloatUserSetting mouseSensitivity;
-        public FloatUserSetting gizmoSize;
+        public FloatClampedUserSetting uiScalingFactor;
+        public FloatClampedUserSetting mouseSensitivity;
+        public FloatClampedUserSetting gizmoSize;
         public IntUserSetting TestInteger;
         public StringUserSetting TestString;
-        public IntUserSetting applicationTargetFramerate;
+        public IntClampedUserSetting applicationTargetFramerate;
 
         public Vec3ProjectSetting TestProjVec3;
         public StringProjectSetting TestProjString;


### PR DESCRIPTION
It was possible to set the application target frame rate to '1'. That was incredibly difficult to reverse.