### PR TITLE
Ref/feature/scene load save

### DIFF
--- a/Assets/Scripts/EditorState/SceneDirectoryState.cs
+++ b/Assets/Scripts/EditorState/SceneDirectoryState.cs
@@ -65,5 +65,13 @@ namespace Assets.Scripts.EditorState
             this.directoryPath = directoryPath;
             this.id = id;
         }
+
+        /// <summary>
+        /// Creates a new SceneDirectoryState and ads a Scene to it.
+        /// </summary>
+        public static SceneDirectoryState CreateNewSceneDirectoryState()
+        {
+            return new SceneDirectoryState { currentScene = new DclScene() };
+        }
     }
 }

--- a/Assets/Scripts/EditorState/SceneManagerState.cs
+++ b/Assets/Scripts/EditorState/SceneManagerState.cs
@@ -62,12 +62,16 @@ namespace Assets.Scripts.EditorState
 
         public SceneDirectoryState GetDirectoryState(string path)
         {
-            return sceneDirectoryStates.First(t => Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)).Value;
+            return sceneDirectoryStates
+                .First(t => (t.Value.directoryPath != null) && (Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)))
+                .Value;
         }
 
         public bool TryGetDirectoryState(string path, out SceneDirectoryState sceneDirectoryState)
         {
-            sceneDirectoryState = sceneDirectoryStates.FirstOrDefault(t => Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)).Value;
+            sceneDirectoryState = sceneDirectoryStates
+                .FirstOrDefault(t => (t.Value.directoryPath != null) && (Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)))
+                .Value;
 
             return sceneDirectoryState != null;
         }

--- a/Assets/Scripts/EditorState/SceneManagerState.cs
+++ b/Assets/Scripts/EditorState/SceneManagerState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using JetBrains.Annotations;
 using Assets.Scripts.Utility;
@@ -42,6 +43,11 @@ namespace Assets.Scripts.EditorState
             }
 
             return sceneDirectoryStates[index];
+        }
+
+        public SceneDirectoryState GetDirectoryState(string path)
+        {
+            return sceneDirectoryStates.First(t => Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)).Value;
         }
 
         [CanBeNull]

--- a/Assets/Scripts/EditorState/SceneManagerState.cs
+++ b/Assets/Scripts/EditorState/SceneManagerState.cs
@@ -27,6 +27,13 @@ namespace Assets.Scripts.EditorState
 
         public void AddSceneDirectoryState(SceneDirectoryState sceneDirectoryState)
         {
+            //check for duplicate directoryPaths (not null)
+            if (sceneDirectoryState.directoryPath != null &&
+                TryGetDirectoryState(sceneDirectoryState.directoryPath, out SceneDirectoryState _))
+            {
+                throw new ArgumentException($"Scenes are not allowed be added twice to sceneDirectoryStates: \"{sceneDirectoryState.directoryPath}\"");
+            }
+
             sceneDirectoryStates.Add(sceneDirectoryState.id, sceneDirectoryState);
         }
 
@@ -48,6 +55,13 @@ namespace Assets.Scripts.EditorState
         public SceneDirectoryState GetDirectoryState(string path)
         {
             return sceneDirectoryStates.First(t => Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)).Value;
+        }
+
+        public bool TryGetDirectoryState(string path, out SceneDirectoryState sceneDirectoryState)
+        {
+            sceneDirectoryState = sceneDirectoryStates.FirstOrDefault(t => Path.GetFullPath(t.Value.directoryPath) == Path.GetFullPath(path)).Value;
+
+            return sceneDirectoryState != null;
         }
 
         [CanBeNull]

--- a/Assets/Scripts/EditorState/SceneManagerState.cs
+++ b/Assets/Scripts/EditorState/SceneManagerState.cs
@@ -37,6 +37,14 @@ namespace Assets.Scripts.EditorState
             sceneDirectoryStates.Add(sceneDirectoryState.id, sceneDirectoryState);
         }
 
+        public void RemoveSceneDirectoryState(SceneDirectoryState sceneDirectoryState)
+        {
+            if (!sceneDirectoryStates.Remove(sceneDirectoryState.id))
+            {
+                throw new ArgumentException($"There is no SceneDirectoryState with the ID \"{sceneDirectoryState.id.Shortened()}\"");
+            }
+        }
+
         private bool Exists(Guid id)
         {
             return sceneDirectoryStates.ContainsKey(id);

--- a/Assets/Scripts/EditorState/SceneManagerState.cs
+++ b/Assets/Scripts/EditorState/SceneManagerState.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Assets.Scripts.Utility;
 
 namespace Assets.Scripts.EditorState
 {
@@ -15,6 +16,11 @@ namespace Assets.Scripts.EditorState
 
         public void SetCurrentSceneIndex(Guid index)
         {
+            if (!Exists(index))
+            {
+                throw new ArgumentOutOfRangeException($"There is no SceneDirectoryState with the ID \"{index.Shortened()}\"");
+            }
+
             currentSceneIndex = index;
         }
 
@@ -23,31 +29,30 @@ namespace Assets.Scripts.EditorState
             sceneDirectoryStates.Add(sceneDirectoryState.id, sceneDirectoryState);
         }
 
-        public bool Exists(Guid id)
+        private bool Exists(Guid id)
         {
             return sceneDirectoryStates.ContainsKey(id);
         }
 
-        [CanBeNull]
         public SceneDirectoryState GetDirectoryState(Guid index)
         {
-            if (sceneDirectoryStates.TryGetValue(index, out var value))
+            if (!Exists(index))
             {
-                return value;
+                throw new ArgumentOutOfRangeException($"There is no SceneDirectoryState with the ID \"{index.Shortened()}\"");
             }
 
-            return null;
+            return sceneDirectoryStates[index];
         }
 
         [CanBeNull]
         public SceneDirectoryState GetCurrentDirectoryState()
         {
-            if (sceneDirectoryStates.TryGetValue(currentSceneIndex, out var value))
+            if (currentSceneIndex == Guid.Empty)
             {
-                return value;
+                return null;
             }
 
-            return null;
+            return sceneDirectoryStates[currentSceneIndex];
         }
     }
 }

--- a/Assets/Scripts/Interaction/GeneralInputInteraction.cs
+++ b/Assets/Scripts/Interaction/GeneralInputInteraction.cs
@@ -414,7 +414,7 @@ namespace Assets.Scripts.Interaction
             if (inputSystemAsset.Hotkeys.Save.triggered)
             {
                 sceneSaveSystem.Save(sceneManagerSystem.GetCurrentDirectoryState());
-                workspaceSaveSystem.Save(unityState.dynamicPanelsCanvas);
+                workspaceSaveSystem.Save();
                 typeScriptGenerationSystem.GenerateTypeScript();
             }
 

--- a/Assets/Scripts/Interaction/GeneralInputInteraction.cs
+++ b/Assets/Scripts/Interaction/GeneralInputInteraction.cs
@@ -18,13 +18,11 @@ namespace Assets.Scripts.Interaction
         private ICommandSystem commandSystem;
         private InputState inputState;
         private Interface3DState interface3DState;
-        private WorkspaceSaveSystem workspaceSaveSystem;
         private GizmoState gizmoState;
         private UnityState unityState;
         private InputHelper inputHelper;
         private CameraState cameraState;
         private EditorEvents editorEvents;
-        private TypeScriptGenerationSystem typeScriptGenerationSystem;
         private EntitySelectSystem entitySelectSystem;
         private ContextMenuSystem contextMenuSystem;
         private SceneManagerSystem sceneManagerSystem;
@@ -35,13 +33,11 @@ namespace Assets.Scripts.Interaction
             ICommandSystem commandSystem,
             InputState inputState,
             Interface3DState interface3DState,
-            WorkspaceSaveSystem workspaceSaveSystem,
             CameraState cameraState,
             GizmoState gizmoState,
             UnityState unityState,
             InputHelper inputHelper,
             EditorEvents editorEvents,
-            TypeScriptGenerationSystem typeScriptGenerationSystem,
             EntitySelectSystem entitySelectSystem,
             ContextMenuSystem contextMenuSystem,
             SceneManagerSystem sceneManagerSystem)
@@ -50,13 +46,11 @@ namespace Assets.Scripts.Interaction
             this.commandSystem = commandSystem;
             this.inputState = inputState;
             this.interface3DState = interface3DState;
-            this.workspaceSaveSystem = workspaceSaveSystem;
             this.gizmoState = gizmoState;
             this.unityState = unityState;
             this.inputHelper = inputHelper;
             this.cameraState = cameraState;
             this.editorEvents = editorEvents;
-            this.typeScriptGenerationSystem = typeScriptGenerationSystem;
             this.entitySelectSystem = entitySelectSystem;
             this.contextMenuSystem = contextMenuSystem;
             this.sceneManagerSystem = sceneManagerSystem;
@@ -410,12 +404,10 @@ namespace Assets.Scripts.Interaction
                 inputState.InState = InputState.InStateType.FocusTransition;
             }
 
-            // When pressing the save hotkey, save the scene and workspace layout
+            // When pressing the save hotkey, save the scene
             if (inputSystemAsset.Hotkeys.Save.triggered)
             {
-                sceneSaveSystem.Save(sceneManagerSystem.GetCurrentDirectoryState());
-                workspaceSaveSystem.Save();
-                typeScriptGenerationSystem.GenerateTypeScript();
+                sceneManagerSystem.SaveCurrentScene();
             }
 
             // When pressing Translate hotkey, enter translation gizmo mode

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -45,9 +45,9 @@ namespace Assets.Scripts.System
         public void Save(SceneDirectoryState sceneDirectoryState)
         {
             DclSceneData sceneData = new DclSceneData(sceneDirectoryState.currentScene);
+            string sceneDirPath = sceneDirectoryState.directoryPath;
 
-            // Create scene directory (if not exists)
-            string sceneDirPath = $"{_pathState.ProjectPath}/dcl-edit/saves/v2/{sceneData.name}.dclscene";
+            // Create scene directory in case it does not exist
             DirectoryInfo sceneDir = Directory.CreateDirectory(sceneDirPath);
 
             // Clear scene directory from files, that are regenerated

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -50,6 +50,23 @@ namespace Assets.Scripts.System
             sceneManagerState.SetCurrentSceneIndex(sceneManagerState.allSceneDirectoryStates.First().id);
         }
 
+        public void SaveCurrentScene()
+        {
+            SaveScene(GetCurrentDirectoryState());
+        }
+
+        public void SaveScene(Guid id)
+        {
+            SaveScene(sceneManagerState.GetDirectoryState(id));
+        }
+
+        private void SaveScene(SceneDirectoryState sceneDirectoryState)
+        {
+            sceneSaveSystem.Save(sceneDirectoryState);
+            workspaceSaveSystem.Save(); // TODO: Save the workspace under proper conditions.
+            typeScriptGenerationSystem.GenerateTypeScript();
+        }
+
         [CanBeNull]
         public DclScene GetCurrentScene()
         {

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -70,20 +70,19 @@ namespace Assets.Scripts.System
         [CanBeNull]
         public DclScene GetCurrentScene()
         {
-            return sceneManagerState.Exists(sceneManagerState.currentSceneIndex) ?
-                GetScene(sceneManagerState.currentSceneIndex) :
-                null;
+            //return null if no scene is open
+            if (sceneManagerState.currentSceneIndex == Guid.Empty)
+            {
+                return null;
+            }
+
+            return GetScene(sceneManagerState.currentSceneIndex);
         }
 
         [NotNull]
         public DclScene GetScene(Guid index)
         {
             var sceneDirectoryState = sceneManagerState.GetDirectoryState(index);
-
-            if (sceneDirectoryState == null)
-            {
-                throw new ArgumentOutOfRangeException($"There is no scene with the id: {index.Shortened()}");
-            }
 
             if (!sceneDirectoryState.IsSceneOpened())
             {

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json.Linq;
 using UnityEngine;
 using Zenject;
 using Exception = System.Exception;
+using USFB;
 
 namespace Assets.Scripts.System
 {
@@ -19,16 +20,33 @@ namespace Assets.Scripts.System
         private SceneManagerState sceneManagerState;
         private PathState pathState;
         private ISceneLoadSystem sceneLoadSystem;
+        private ISceneSaveSystem sceneSaveSystem;
+        private WorkspaceSaveSystem workspaceSaveSystem;
+        private TypeScriptGenerationSystem typeScriptGenerationSystem;
+        private SceneViewSystem sceneViewSystem;
+        private MenuBarSystem menuBarSystem;
 
         [Inject]
         public void Construct(
             SceneManagerState sceneManagerState,
             PathState pathState,
-            ISceneLoadSystem sceneLoadSystem)
+            ISceneLoadSystem sceneLoadSystem,
+            ISceneSaveSystem sceneSaveSystem,
+            WorkspaceSaveSystem workspaceSaveSystem,
+            TypeScriptGenerationSystem typeScriptGenerationSystem,
+            SceneViewSystem sceneViewSystem,
+            MenuBarSystem menuBarSystem)
         {
             this.sceneManagerState = sceneManagerState;
             this.pathState = pathState;
             this.sceneLoadSystem = sceneLoadSystem;
+            this.sceneSaveSystem = sceneSaveSystem;
+            this.workspaceSaveSystem = workspaceSaveSystem;
+            this.typeScriptGenerationSystem = typeScriptGenerationSystem;
+            this.sceneViewSystem = sceneViewSystem;
+            this.menuBarSystem = menuBarSystem;
+
+            CreateMenuBarItems();
         }
 
         public void DiscoverScenes()
@@ -45,26 +63,156 @@ namespace Assets.Scripts.System
             }
         }
 
-        public void SetFirstSceneAsCurrent()
+        /// <summary>
+        /// Set any scene as current scene. Undefinded behaviour.
+        /// </summary>
+        public void SetFirstSceneAsCurrentScene()
         {
-            sceneManagerState.SetCurrentSceneIndex(sceneManagerState.allSceneDirectoryStates.First().id);
+            SetCurrentScene(sceneManagerState.allSceneDirectoryStates.First().id);
         }
 
+        /// <summary>
+        /// Create a new scene and set it as current scene
+        /// </summary>
+        public void SetNewScneneAsCurrentScene()
+        {
+            SceneDirectoryState newScene = SceneDirectoryState.CreateNewSceneDirectoryState();
+            sceneManagerState.AddSceneDirectoryState(newScene);
+            SetCurrentScene(newScene.id);
+
+        }
+
+        /// <summary>
+        /// Start an open file dialog and set the resulting scene as current scene.
+        /// </summary>
+        /// <exception cref="NotImplementedException"></exception>
+        public void SetDialogAsCurrentScene()
+        {
+            string[] paths = StandaloneFileBrowser.OpenFolderPanel("Open Scene", pathState.ProjectPath, false);
+
+            // check for canceled dialog
+            if (paths.Length == 0)
+            {
+                return;
+            }
+
+            SetCurrentScene(paths[0]);
+        }
+
+        /// <summary>
+        /// Set the given scene as current scene.
+        /// </summary>
+        /// <param name="path">The scene to set as current scene.</param>
+        public void SetCurrentScene(string path)
+        {
+            SetCurrentScene(sceneManagerState.GetDirectoryState(path).id);
+        }
+
+        /// <summary>
+        /// Set the given scene as current scene.
+        /// </summary>
+        /// <param name="id">The ID of the scene to set as current scene.</param>
+        public void SetCurrentScene(Guid id)
+        {
+            sceneManagerState.SetCurrentSceneIndex(id);
+            sceneViewSystem.SetUpCurrentScene();
+        }
+
+        /// <summary>
+        /// Save the current scene to its directory.
+        /// If it has no directory yet, this will result in save as.
+        /// Note: Save as might actually not save, if the user does cancel the dialog.
+        /// </summary>
         public void SaveCurrentScene()
         {
             SaveScene(GetCurrentDirectoryState());
         }
 
+        /// <summary>
+        /// Save the given scene to its directory.
+        /// If it has no directory yet, this will result in save as.
+        /// Note: Save as might actually not save, if the user does cancel the dialog.
+        /// </summary>
+        /// <param name="id">The ID of the scene to save.</param>
         public void SaveScene(Guid id)
         {
             SaveScene(sceneManagerState.GetDirectoryState(id));
         }
 
+        /// <summary>
+        /// Save the given scene to its directory.
+        /// If it has no directory yet, this will result in save as.
+        /// Note: Save as might actually not save, if the user does cancel the dialog.
+        /// </summary>
+        /// <param name="sceneDirectoryState">The SceneDirectoryState of the scene to save.</param>
         private void SaveScene(SceneDirectoryState sceneDirectoryState)
         {
-            sceneSaveSystem.Save(sceneDirectoryState);
-            workspaceSaveSystem.Save(); // TODO: Save the workspace under proper conditions.
-            typeScriptGenerationSystem.GenerateTypeScript();
+            // Use save as if scene has no path yet
+            if (sceneDirectoryState.directoryPath == null)
+            {
+                SaveSceneAs(sceneDirectoryState);
+            }
+            else
+            {
+                sceneSaveSystem.Save(sceneDirectoryState);
+                workspaceSaveSystem.Save(); // TODO: Save the workspace under proper conditions.
+                typeScriptGenerationSystem.GenerateTypeScript();
+            }
+        }
+
+        /// <summary>
+        /// Save the current scene to its directory with dialog.
+        /// Note: This might actually not save, if the user does cancel the dialog.
+        /// </summary>
+        public void SaveCurrentSceneAs()
+        {
+            SaveSceneAs(GetCurrentDirectoryState());
+        }
+
+        /// <summary>
+        /// Save the given scene to its directory with dialog.
+        /// Note: This might actually not save, if the user does cancel the dialog.
+        /// </summary>
+        /// <param name="id">The SceneDirectoryState of the scene to save.</param>
+        public void SaveSceneAs(Guid id)
+        {
+            SaveSceneAs(sceneManagerState.GetDirectoryState(id));
+        }
+
+        /// <summary>
+        /// Save the given scene to its directory with dialog.
+        /// Note: This might actually not save, if the user does cancel the dialog.
+        /// </summary>
+        /// <param name="sceneDirectoryState">The SceneDirectoryState of the scene to save.</param>
+        private void SaveSceneAs(SceneDirectoryState sceneDirectoryState)
+        {
+            string path = sceneDirectoryState.directoryPath;
+
+            string oldPath;
+            string oldName;
+            if (path == null)
+            {
+                oldPath = pathState.ProjectPath;
+                oldName = "New Scene";
+            }
+            else
+            {
+                path = Path.GetFullPath(path); //normalize path format (e.g. turn '/' into '\\')
+                oldPath = path.Substring(0, path.LastIndexOf(Path.DirectorySeparatorChar));
+                oldName = path.Substring(path.LastIndexOf(Path.DirectorySeparatorChar) + 1);
+                oldName = oldName.Substring(0, oldName.LastIndexOf('.'));
+            }
+
+            path = StandaloneFileBrowser.SaveFilePanel("Save Scene", oldPath, oldName, "dclscene");
+
+            // check for canceled dialog
+            if (path == "")
+            {
+                return;
+            }
+
+            sceneDirectoryState.directoryPath = path;
+            SaveScene(sceneDirectoryState);
         }
 
         [CanBeNull]
@@ -80,9 +228,9 @@ namespace Assets.Scripts.System
         }
 
         [NotNull]
-        public DclScene GetScene(Guid index)
+        public DclScene GetScene(Guid id)
         {
-            var sceneDirectoryState = sceneManagerState.GetDirectoryState(index);
+            var sceneDirectoryState = sceneManagerState.GetDirectoryState(id);
 
             if (!sceneDirectoryState.IsSceneOpened())
             {
@@ -129,6 +277,14 @@ namespace Assets.Scripts.System
         public SceneDirectoryState GetCurrentDirectoryState()
         {
             return sceneManagerState.GetCurrentDirectoryState();
+        }
+
+        private void CreateMenuBarItems()
+        {
+            menuBarSystem.AddMenuItem("File/New Scene", SetNewScneneAsCurrentScene);
+            menuBarSystem.AddMenuItem("File/Open Scene", SetDialogAsCurrentScene);
+            menuBarSystem.AddMenuItem("File/Save Scene", SaveCurrentScene);
+            menuBarSystem.AddMenuItem("File/Save Scene As...", SaveCurrentSceneAs);
         }
     }
 }

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -209,6 +209,12 @@ namespace Assets.Scripts.System
                 return;
             }
 
+            //remove any potential scene that will be overridden
+            if (sceneManagerState.TryGetDirectoryState(newPath, out SceneDirectoryState sceneDirectoryStateToOverride))
+            {
+                sceneManagerState.RemoveSceneDirectoryState(sceneDirectoryStateToOverride);
+            }
+
             sceneDirectoryState.directoryPath = newPath;
             SaveScene(sceneDirectoryState);
 

--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -36,9 +36,7 @@ namespace Assets.Scripts.System
             sceneManagerSystem.DiscoverScenes();
 
             // TODO: load proper scene. Work around is to load the first scene
-            sceneManagerSystem.SetFirstSceneAsCurrent();
-
-            sceneViewSystem.SetUpCurrentScene();
+            sceneManagerSystem.SetFirstSceneAsCurrentScene();
         }
 
         void Start()

--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -11,7 +11,6 @@ namespace Assets.Scripts.System
 
         // dependencies
         private WorkspaceSaveSystem _workspaceSaveSystem;
-        private UnityState _unityState;
         private IPathState _pathState;
         private FrameTimeSystem _frameTimeSystem;
         private SceneManagerSystem sceneManagerSystem;
@@ -20,14 +19,12 @@ namespace Assets.Scripts.System
         [Inject]
         private void Construct(
             WorkspaceSaveSystem workspaceSaveSystem,
-            UnityState unityState,
             IPathState pathState,
             FrameTimeSystem frameTimeSystem,
             SceneManagerSystem sceneManagerSystem,
             SceneViewSystem sceneViewSystem)
         {
             _workspaceSaveSystem = workspaceSaveSystem;
-            _unityState = unityState;
             _pathState = pathState;
             _frameTimeSystem = frameTimeSystem;
             this.sceneManagerSystem = sceneManagerSystem;
@@ -46,7 +43,7 @@ namespace Assets.Scripts.System
 
         void Start()
         {
-            _workspaceSaveSystem.Load(_unityState.dynamicPanelsCanvas);
+            _workspaceSaveSystem.Load();
 
             _frameTimeSystem.SetApplicationTargetFramerate();
         }

--- a/Assets/Scripts/System/Systems.asmdef
+++ b/Assets/Scripts/System/Systems.asmdef
@@ -11,7 +11,9 @@
         "GUID:47588e3d37f573d458b0eaa6cc8109c2",
         "GUID:9bf848f31e601a249a6bebdc53287470",
         "GUID:e0946e506e3794c42a0a4080d32eea3a",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:dfd4dd069f777a943b33ee54f1a6a649",
+        "GUID:69f072ba8fc33de469fe24734c3f64fa"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/System/WorkspaceSaveSystem.cs
+++ b/Assets/Scripts/System/WorkspaceSaveSystem.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using DynamicPanels;
 using System;
 using Zenject;
+using Assets.Scripts.EditorState;
 
 namespace Assets.Scripts.System
 {
@@ -9,23 +10,29 @@ namespace Assets.Scripts.System
     {
         //Dependency
         private SettingsSystem settingSystem;
+        private UnityState unityState;
 
         [Inject]
         public void Construct(
-            SettingsSystem settingSystem)
+            SettingsSystem settingSystem,
+            UnityState unityState)
         {
             this.settingSystem = settingSystem;
+            this.unityState = unityState;
         }
 
-        public void Save(DynamicPanelsCanvas canvas)
+        public void Save()
         {
+            DynamicPanelsCanvas canvas = unityState.dynamicPanelsCanvas;
             byte[] data = PanelSerialization.SerializeCanvasToArray(canvas);
             string dataString = Convert.ToBase64String(data);
             settingSystem.panelSize.Set(dataString);
         }
 
-        public void Load(DynamicPanelsCanvas canvas)
+        public void Load()
         {
+            DynamicPanelsCanvas canvas = unityState.dynamicPanelsCanvas;
+
             if (settingSystem.panelSize.Get() == "")
             {
                 Debug.Log("Layout save is empty");

--- a/Assets/Scripts/Visuals/MenuBarVisuals.cs
+++ b/Assets/Scripts/Visuals/MenuBarVisuals.cs
@@ -33,6 +33,7 @@ namespace Assets.Scripts.Visuals
             panel = new PanelAtom.Data();
             panel.layoutDirection = UiHandler.PanelHandler.LayoutDirection.Horizontal;
 
+            UpdateMenuBar(); // initial setup
             SetupEventListeners();
         }
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     }
   ],
   "dependencies": {
+    "com.gkngkc.usfb": "https://github.com/Sov3rain/unity-standalone-file-browser.git#upm",
     "com.svermeulen.extenject": "https://github.com/Mathijs-Bakker/Extenject.git?path=/UnityProject/Assets/Plugins/Zenject/#9.2.1",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.ide.rider": "2.0.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,5 +1,12 @@
 {
   "dependencies": {
+    "com.gkngkc.usfb": {
+      "version": "https://github.com/Sov3rain/unity-standalone-file-browser.git#upm",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "2ef27bb51dd002e6e61e6ab063e9117c14d54f00"
+    },
     "com.svermeulen.extenject": {
       "version": "https://github.com/Mathijs-Bakker/Extenject.git?path=/UnityProject/Assets/Plugins/Zenject/#9.2.1",
       "depth": 0,


### PR DESCRIPTION
Use the [UnityStandaloneFileBrowser](https://github.com/gkngkc/UnityStandaloneFileBrowser) to create the open/save dialogs

Fill menu bar in `SceneManagerSystem` In the Constructor (add new function).
- `File/New Scene` Open a new scene.
- `File/Open scene ...` Open a dialog to open a scene.
- `File/Save scene` Save the current scene. When there is no save file => save as.
- `File/Save scene as ...` Open a dialog to save the scene to a specific path.