### PR TITLE
remove content size fitter

### DIFF
--- a/Assets/Prefabs/UIDesign/Atoms/MenuBarButton.prefab
+++ b/Assets/Prefabs/UIDesign/Atoms/MenuBarButton.prefab
@@ -174,7 +174,6 @@ GameObject:
   - component: {fileID: 7265437178497408458}
   - component: {fileID: 7265437178497408463}
   - component: {fileID: 7265437178497408456}
-  - component: {fileID: 7265437178497408457}
   m_Layer: 5
   m_Name: Text (TMP)
   m_TagString: Untagged
@@ -198,7 +197,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 50, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7265437178497408463
@@ -298,17 +297,3 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &7265437178497408457
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7265437178497408459}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_HorizontalFit: 2
-  m_VerticalFit: 0


### PR DESCRIPTION
The menu bar button does not need a content size fitter. The layout group already fits the text's size.