### PR TITLE
Ref/bug/fix startup sequence

### DIFF
--- a/Assets/Scripts/EditorState/SceneDirectoryState.cs
+++ b/Assets/Scripts/EditorState/SceneDirectoryState.cs
@@ -59,19 +59,34 @@ namespace Assets.Scripts.EditorState
         {
             id = Guid.NewGuid();
         }
+        
+        /**
+         * <summary>
+         * The version of the dcl-edit project
+         * </summary>
+         */
+        public readonly DclEditVersion dclEditVersion = DclEditVersion.None;
 
-        public SceneDirectoryState(string directoryPath, Guid id)
+        public SceneDirectoryState(string directoryPath, Guid id, DclEditVersion dclEditVersion = DclEditVersion.Beta)
         {
             this.directoryPath = directoryPath;
             this.id = id;
+            this.dclEditVersion = dclEditVersion;
         }
 
         /// <summary>
-        /// Creates a new SceneDirectoryState and ads a Scene to it.
+        /// Creates a new SceneDirectoryState and adds a Scene to it.
         /// </summary>
         public static SceneDirectoryState CreateNewSceneDirectoryState()
         {
             return new SceneDirectoryState { currentScene = new DclScene() };
         }
+    }
+    
+    public enum DclEditVersion
+    {
+        None,
+        Alpha,
+        Beta
     }
 }

--- a/Assets/Scripts/Installers/DclEditorInstaller.cs
+++ b/Assets/Scripts/Installers/DclEditorInstaller.cs
@@ -10,10 +10,6 @@ using Zenject;
 
 public class DclEditorInstaller : MonoInstaller
 {
-    [Header("Scene Loading and Saving")]
-    [SerializeField]
-    private bool _loadSceneFromVersion1 = false;
-
     [Header("Prefabs")]
     [SerializeField]
     private GameObject _entityVisualPrefab;
@@ -40,15 +36,9 @@ public class DclEditorInstaller : MonoInstaller
 
     public override void InstallBindings()
     {
-        if (_loadSceneFromVersion1)
-        {
-            Container.Bind<ISceneLoadSystem>().To<LoadFromVersion1System>().AsSingle();
-            Container.Bind<ISceneSaveSystem>().To<SceneLoadSaveSystem>().AsSingle();
-        }
-        else
-        {
+        Container.BindInterfacesAndSelfTo<LoadFromVersion1System>().AsSingle();
+
         Container.BindInterfacesAndSelfTo<SceneLoadSaveSystem>().AsSingle();
-        }
 
         Container.BindInterfacesAndSelfTo<CommandSystem>().AsSingle();
 

--- a/Assets/Scripts/Installers/DclEditorInstaller.cs
+++ b/Assets/Scripts/Installers/DclEditorInstaller.cs
@@ -47,7 +47,7 @@ public class DclEditorInstaller : MonoInstaller
         }
         else
         {
-            Container.BindInterfacesAndSelfTo<SceneLoadSaveSystem>().AsSingle();
+        Container.BindInterfacesAndSelfTo<SceneLoadSaveSystem>().AsSingle();
         }
 
         Container.BindInterfacesAndSelfTo<CommandSystem>().AsSingle();
@@ -156,5 +156,7 @@ public class DclEditorInstaller : MonoInstaller
         Container.BindInterfacesAndSelfTo<MenuBarState>().AsSingle();
 
         Container.BindInterfacesAndSelfTo<MenuBarSystem>().AsSingle();
+        
+        Container.BindInterfacesAndSelfTo<CheckVersionSystem>().AsSingle();
     }
 }

--- a/Assets/Scripts/System/CheckVersionSystem.cs
+++ b/Assets/Scripts/System/CheckVersionSystem.cs
@@ -1,0 +1,47 @@
+using System.IO;
+using Assets.Scripts.EditorState;
+using Zenject;
+
+namespace Assets.Scripts.System
+{
+    public class CheckVersionSystem
+    {
+        private IPathState pathState;
+
+        [Inject]
+        public void Construct(
+            IPathState pathState)
+        {
+            this.pathState = pathState;
+        }
+
+        public bool CheckDclSceneExists()
+        {
+            return File.Exists(Path.Combine(pathState.ProjectPath, "scene.json"));
+        }
+
+        private string[] GetBetaProjectPaths()
+        {
+            return Directory.GetDirectories(pathState.ProjectPath, "*.dclscene", SearchOption.AllDirectories);
+        }
+
+        public bool TryGetBetaPaths(out string[] betaPaths)
+        {
+            betaPaths = GetBetaProjectPaths();
+            return betaPaths.Length > 0;
+        }
+
+        private string GetAlphaProjectPath()
+        {
+            return pathState.ProjectPath;
+        }
+
+        public bool CheckForAlpha()
+        {
+            var alphaPath = GetAlphaProjectPath();
+            return File.Exists(Path.Combine(alphaPath, "dcl-edit/saves/assets.json")) &&
+                   File.Exists(Path.Combine(alphaPath, "dcl-edit/saves/save.json")) &&
+                   File.Exists(Path.Combine(alphaPath, "dcl-edit/saves/project.json"));
+        }
+    }
+}

--- a/Assets/Scripts/System/CheckVersionSystem.cs.meta
+++ b/Assets/Scripts/System/CheckVersionSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4f23a68c84a840c4926cb241b27e2ccf
+timeCreated: 1673046122

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using Assets.Scripts.EditorState;
 using UnityEngine;
+using Zenject;
 using Debug = UnityEngine.Debug;
 
 namespace Assets.Scripts.System
@@ -36,7 +37,15 @@ namespace Assets.Scripts.System
     {
         // Dependencies
         private IPathState _pathState;
+        private LoadFromVersion1System loadFromVersion1System;
 
+        [Inject]
+        public void Construct(
+            LoadFromVersion1System loadFromVersion1System)
+        {
+            this.loadFromVersion1System = loadFromVersion1System;
+        }
+        
         public SceneLoadSaveSystem(IPathState pathState)
         {
             _pathState = pathState;
@@ -124,7 +133,7 @@ namespace Assets.Scripts.System
 
             sceneDirectoryState.currentScene = scene;
         }
-
+        
         /**
          * <summary>
          * Creates a save file for a given entity

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -51,6 +51,10 @@ namespace Assets.Scripts.System
             _pathState = pathState;
         }
 
+        /// <summary>
+        /// Save a dcl-edit beta scene
+        /// </summary>
+        /// <param name="sceneDirectoryState">The directory state of the scene</param>
         public void Save(SceneDirectoryState sceneDirectoryState)
         {
             DclSceneData sceneData = new DclSceneData(sceneDirectoryState.currentScene);
@@ -86,6 +90,10 @@ namespace Assets.Scripts.System
             }
         }
 
+        /// <summary>
+        /// Load a dcl-edit beta scene
+        /// </summary>
+        /// <param name="sceneDirectoryState">The directory state of the scene</param>
         public void Load(SceneDirectoryState sceneDirectoryState)
         {
             var scenePath = sceneDirectoryState.directoryPath;
@@ -134,6 +142,15 @@ namespace Assets.Scripts.System
             sceneDirectoryState.currentScene = scene;
         }
         
+        /// <summary>
+        /// Load a dcl-edit alpha scene
+        /// </summary>
+        /// <param name="sceneDirectoryState">The directory state of the scene</param>
+        public void LoadV1(SceneDirectoryState sceneDirectoryState)
+        {
+            loadFromVersion1System.Load(sceneDirectoryState);
+        }
+
         /**
          * <summary>
          * Creates a save file for a given entity
@@ -157,6 +174,11 @@ namespace Assets.Scripts.System
             return path;
         }
 
+        /// <summary>
+        /// Load an entity from a file into a scene
+        /// </summary>
+        /// <param name="scene">The scene into which the entity should be loaded</param>
+        /// <param name="absolutePath">The path from which to load the entity</param>
         public void LoadEntityFile(DclScene scene, string absolutePath)
         {
             var json = File.ReadAllText(absolutePath);


### PR DESCRIPTION
The scene manager now checks if there is a dcl project and if so, continues to check for beta, alpha or no dcl-edit projects inside the dcl project folder. If a alpha or beta project is found, and there is no existing directory state, the scene's version gets written into a new scene directory state. If no dcl-edit project exists, a new scene directory state with a new scene is created. When getscene gets called, the version of the scene gets checked and the appropriate action (like loading with v1) gets taken.