### PR TITLE
Ref/feature/save scene metadata

### DIFF
--- a/Assets/Scripts/EditorState/JsonSettingState.cs
+++ b/Assets/Scripts/EditorState/JsonSettingState.cs
@@ -11,11 +11,11 @@ namespace Assets.Scripts.EditorState
     public abstract class JsonSettingState
     {
         // Dependencies
-        protected PathState _pathState;
+        protected IPathState _pathState;
         protected SceneManagerState sceneManagerState;
 
         [Inject]
-        private void Constructor(PathState pathState, SceneManagerState sceneManagerState)
+        public void Construct(IPathState pathState, SceneManagerState sceneManagerState)
         {
             _pathState = pathState;
             this.sceneManagerState = sceneManagerState;
@@ -50,7 +50,7 @@ namespace Assets.Scripts.EditorState
             }
         }
 
-        protected abstract void SaveSettings();
+        public abstract void SaveSettings();
         protected abstract void LoadSettings();
     }
 
@@ -60,7 +60,7 @@ namespace Assets.Scripts.EditorState
 
         private string _projectSettingPath => _projectSettingDirectoryPath + "settings.json";
 
-        protected override void SaveSettings()
+        public override void SaveSettings()
         {
             if (!Directory.Exists(_projectSettingDirectoryPath))
             {
@@ -87,7 +87,7 @@ namespace Assets.Scripts.EditorState
 
     public class SceneSettingState : JsonSettingState
     {
-        protected override void SaveSettings()
+        public override void SaveSettings()
         {
             if (!sceneManagerState.GetCurrentDirectoryState()?.IsSceneOpened() ?? true)
             {

--- a/Assets/Scripts/EditorState/SceneDirectoryState.cs
+++ b/Assets/Scripts/EditorState/SceneDirectoryState.cs
@@ -1,9 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
 using Assets.Scripts.SceneState;
 using JetBrains.Annotations;
-using UnityEngine;
+using System;
+using System.Collections.Generic;
 
 
 namespace Assets.Scripts.EditorState
@@ -54,6 +52,8 @@ namespace Assets.Scripts.EditorState
          * </summary>
          */
         public Guid id;
+
+        public string name = "New Scene";
 
         public SceneDirectoryState()
         {

--- a/Assets/Scripts/Installers/DclEditorInstaller.cs
+++ b/Assets/Scripts/Installers/DclEditorInstaller.cs
@@ -36,9 +36,9 @@ public class DclEditorInstaller : MonoInstaller
 
     public override void InstallBindings()
     {
-        Container.BindInterfacesAndSelfTo<LoadFromVersion1System>().AsSingle();
+        Container.Bind<LoadFromVersion1System>().To<LoadFromVersion1System>().AsSingle();
 
-        Container.BindInterfacesAndSelfTo<SceneLoadSaveSystem>().AsSingle();
+        Container.Bind(typeof(ISceneLoadSystem), typeof(ISceneSaveSystem)).To<SceneLoadSaveSystem>().AsSingle();
 
         Container.BindInterfacesAndSelfTo<CommandSystem>().AsSingle();
 
@@ -149,7 +149,7 @@ public class DclEditorInstaller : MonoInstaller
         Container.BindInterfacesAndSelfTo<MenuBarState>().AsSingle();
 
         Container.BindInterfacesAndSelfTo<MenuBarSystem>().AsSingle();
-        
+
         Container.BindInterfacesAndSelfTo<CheckVersionSystem>().AsSingle();
     }
 }

--- a/Assets/Scripts/SceneState/DclScene.cs
+++ b/Assets/Scripts/SceneState/DclScene.cs
@@ -6,8 +6,6 @@ namespace Assets.Scripts.SceneState
 {
     public class DclScene
     {
-        public string name = "New Scene";
-
         private Dictionary<Guid, DclEntity> _allEntities = new Dictionary<Guid, DclEntity>();
         private Dictionary<Guid, DclEntity> _allFloatingEntities = new Dictionary<Guid, DclEntity>();
 

--- a/Assets/Scripts/System/LoadFromVersion1System.cs
+++ b/Assets/Scripts/System/LoadFromVersion1System.cs
@@ -151,6 +151,8 @@ namespace Assets.Scripts.System
             sceneDirectoryState.currentScene = newScene;
         }
 
+        public void LoadV1(SceneDirectoryState sceneDirectoryState) => Load(sceneDirectoryState);
+
         private void ChangeToLocal(DclEntity entity, DclTransformComponent dclParentTransform)
         {
             // can be null

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -26,6 +26,7 @@ namespace Assets.Scripts.System
     public interface ISceneLoadSystem
     {
         void Load(SceneDirectoryState sceneDirectoryState);
+        void LoadV1(SceneDirectoryState sceneDirectoryState);
     }
 
     public interface ISceneSaveSystem

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -37,7 +37,6 @@ namespace Assets.Scripts.System
     public class SceneLoadSaveSystem : ISceneLoadSystem, ISceneSaveSystem
     {
         // Dependencies
-        private IPathState _pathState;
         private LoadFromVersion1System loadFromVersion1System;
 
         [Inject]
@@ -47,10 +46,6 @@ namespace Assets.Scripts.System
             this.loadFromVersion1System = loadFromVersion1System;
         }
         
-        public SceneLoadSaveSystem(IPathState pathState)
-        {
-            _pathState = pathState;
-        }
 
         /// <summary>
         /// Save a dcl-edit beta scene

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -57,7 +57,6 @@ namespace Assets.Scripts.System
         /// <param name="sceneDirectoryState">The directory state of the scene</param>
         public void Save(SceneDirectoryState sceneDirectoryState)
         {
-            DclSceneData sceneData = new DclSceneData(sceneDirectoryState.currentScene);
             string sceneDirPath = sceneDirectoryState.directoryPath;
 
             // Create scene directory in case it does not exist
@@ -187,16 +186,6 @@ namespace Assets.Scripts.System
             entityData.MakeEntity(scene);
         }
 
-
-        public struct DclSceneData
-        {
-            public string name;
-
-            public DclSceneData(DclScene scene)
-            {
-                this.name = scene.name;
-            }
-        }
         public struct DclEntityData
         {
             public string customName;

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -1,3 +1,4 @@
+using Assets.Scripts.EditorState;
 using Assets.Scripts.SceneState;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -5,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Assets.Scripts.EditorState;
 using UnityEngine;
 using Zenject;
 using Debug = UnityEngine.Debug;
@@ -45,7 +45,7 @@ namespace Assets.Scripts.System
         {
             this.loadFromVersion1System = loadFromVersion1System;
         }
-        
+
 
         /// <summary>
         /// Save a dcl-edit beta scene
@@ -53,90 +53,100 @@ namespace Assets.Scripts.System
         /// <param name="sceneDirectoryState">The directory state of the scene</param>
         public void Save(SceneDirectoryState sceneDirectoryState)
         {
-            string sceneDirPath = sceneDirectoryState.directoryPath;
+            try
+            {
+                // Create scene directory in case it does not exist
+                DirectoryInfo sceneDir = Directory.CreateDirectory(sceneDirectoryState.directoryPath);
 
-            // Create scene directory in case it does not exist
-            DirectoryInfo sceneDir = Directory.CreateDirectory(sceneDirPath);
-
-            // Clear scene directory from files, that are regenerated
-            foreach (FileInfo file in sceneDir
-                         .GetFiles()
-                         .Where(f => sceneDirectoryState.loadedFilePathsInScene.Contains(NormalizePath(f.FullName))))
+                // Clear scene directory from files, that are regenerated
+                foreach (FileInfo file in sceneDir
+                             .GetFiles()
+                             .Where(f => sceneDirectoryState.loadedFilePathsInScene.Contains(NormalizePath(f.FullName))))
                 // Only delete files that were loaded into the scene.
                 // This prevents the deletion of faulty entity files and files the user added manually into the scene folder
-            {
-                file.Delete();
+                {
+                    file.Delete();
+                }
+
+                sceneDirectoryState.loadedFilePathsInScene.Clear();
+
+                // Create scene metadata file
+                SceneManagerSystem.SceneFileContents sceneFileContents = new SceneManagerSystem.SceneFileContents
+                {
+                    id = sceneDirectoryState.id,
+                    relativePath = sceneDirectoryState.directoryPath,
+                    settings = new JObject(),
+                    dclEditVersion = DclEditVersion.Beta
+                };
+                string sceneFilePath = Path.Combine(sceneDirectoryState.directoryPath, "scene.json");
+                string sceneFileContentsJson = JsonConvert.SerializeObject(sceneFileContents);
+                File.WriteAllText(sceneFilePath, sceneFileContentsJson);
+
+                sceneDirectoryState.loadedFilePathsInScene.Add(NormalizePath(sceneFilePath));
+
+                // Create entity files
+                foreach (var entity in sceneDirectoryState.currentScene!.AllEntities.Select(pair => pair.Value))
+                {
+                    var newPath = CreateEntityFile(entity, sceneDirectoryState.directoryPath);
+
+                    sceneDirectoryState.loadedFilePathsInScene.Add(NormalizePath(newPath));
+                }
             }
-
-            sceneDirectoryState.loadedFilePathsInScene.Clear();
-
-            // Create scene metadata file
-            string metadataFilePath = $"{sceneDirPath}/scene.json";
-            File.WriteAllText(metadataFilePath, "");
-
-            sceneDirectoryState.loadedFilePathsInScene.Add(NormalizePath(metadataFilePath));
-
-            // Create entity files
-            foreach (var entity in sceneDirectoryState.currentScene!.AllEntities.Select(pair => pair.Value))
+            catch (Exception e)
             {
-                var newPath = CreateEntityFile(entity, sceneDirPath);
-
-                sceneDirectoryState.loadedFilePathsInScene.Add(NormalizePath(newPath));
+                Debug.LogWarning($"Error while saving scene (path: '{sceneDirectoryState.directoryPath}'): {e}");
             }
         }
 
         /// <summary>
-        /// Load a dcl-edit beta scene
+        /// Tries to load a scene from the path in the given SceneDirectoryState. If a scene can be found, the
+        /// SceneDirectoryState object is filled.
         /// </summary>
-        /// <param name="sceneDirectoryState">The directory state of the scene</param>
+        /// <param name="sceneDirectoryState"></param>
         public void Load(SceneDirectoryState sceneDirectoryState)
         {
-            var scenePath = sceneDirectoryState.directoryPath;
+            string pathToSceneMetadataFile = Path.Combine(sceneDirectoryState.directoryPath, "scene.json");
 
-            // return if path isn't directory
-            if (!Directory.Exists(scenePath))
+            // Read scene metadata
+            try
             {
-                Debug.LogError("trying to load non existing scene");
-                return;
+                string sceneFileJson = File.ReadAllText(pathToSceneMetadataFile);
+                SceneManagerSystem.SceneFileContents sceneFileContents = JsonConvert.DeserializeObject<SceneManagerSystem.SceneFileContents>(sceneFileJson);
+                sceneDirectoryState.id = sceneFileContents.id;
+                sceneDirectoryState.loadedFilePathsInScene.Add("scene.json");
             }
-
-            // path should end with ".dclscene"
-            if (!scenePath.EndsWith(".dclscene") && !scenePath.EndsWith(".dclscene/"))
+            catch (Exception e)
             {
-                Debug.LogWarning("scene folders should end with \".dclscene\"");
+                Debug.LogWarning($"Error while loading scene (path: '{sceneDirectoryState.directoryPath}'): {e}");
+                sceneDirectoryState.id = Guid.NewGuid();
             }
+            // Directory name ends in .dclscene, so GetFileNameWithoutExtension returns the name of the directory
+            sceneDirectoryState.name = Path.GetFileNameWithoutExtension(new DirectoryInfo(sceneDirectoryState.directoryPath).Name);
+            sceneDirectoryState.currentScene = new DclScene();
 
-            var scene = new DclScene();
 
-            var directoryInfo = new DirectoryInfo(scenePath);
-            foreach (var fileName in directoryInfo.GetFiles().Select(fi => fi.Name))
+            // Read entity files
+            try
             {
-                if (!fileName.EndsWith(".json"))
+                DirectoryInfo sceneDirInfo = new DirectoryInfo(sceneDirectoryState.directoryPath);
+                foreach (var fileName in sceneDirInfo.GetFiles().Select(fi => fi.Name))
                 {
-                    continue;
-                }
+                    if (!fileName.EndsWith(".json") || fileName == "scene.json")
+                    {
+                        continue;
+                    }
 
-                if (fileName == "scene.json")
-                {
-                    sceneDirectoryState.loadedFilePathsInScene.Add("scene.json");
-                    continue;
-                }
-
-                try
-                {
-                    LoadEntityFile(scene, directoryInfo.FullName + "/" + fileName);
+                    LoadEntityFile(sceneDirectoryState.currentScene, Path.Combine(sceneDirInfo.FullName, fileName));
 
                     sceneDirectoryState.loadedFilePathsInScene.Add(fileName);
                 }
-                catch (Exception e)
-                {
-                    Debug.LogError(e.Message);
-                }
             }
-
-            sceneDirectoryState.currentScene = scene;
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Error while loading entity files (path: '{sceneDirectoryState.directoryPath}'): {e}");
+            }
         }
-        
+
         /// <summary>
         /// Load a dcl-edit alpha scene
         /// </summary>
@@ -158,15 +168,27 @@ namespace Assets.Scripts.System
          */
         public string CreateEntityFile(DclEntity entity, string sceneDirectoryPath)
         {
-            DclEntityData data = new DclEntityData(entity);
-            string dataJson = JsonConvert.SerializeObject(data, Formatting.Indented);
+            try
+            {
+                // Search and remove existing entity files that contain the entities ID
+                string[] foundFiles = Directory.GetFiles(sceneDirectoryPath, "*" + entity.Id.ToString() + ".json");
+                foreach (string file in foundFiles)
+                {
+                    File.Delete(file);
+                }
 
-            string filename = data.customName.Replace(' ', '_') + "-" + data.guid.ToString() + ".json";
-
-            var path = $"{sceneDirectoryPath}/{filename}";
-            File.WriteAllText(path, dataJson);
-
-            return path;
+                // Write entity data to file
+                DclEntityData data = new DclEntityData(entity);
+                string dataJson = JsonConvert.SerializeObject(data, Formatting.Indented);
+                string filename = data.customName.Replace(' ', '_') + "-" + data.guid.ToString() + ".json";
+                string path = $"{sceneDirectoryPath}/{filename}";
+                File.WriteAllText(path, dataJson);
+                return path;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -1,16 +1,13 @@
+using Assets.Scripts.EditorState;
+using Assets.Scripts.SceneState;
+using JetBrains.Annotations;
+using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Linq;
-using Assets.Scripts.EditorState;
-using Assets.Scripts.SceneState;
-using Assets.Scripts.Utility;
-using JetBrains.Annotations;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using UnityEngine;
-using Zenject;
-using Exception = System.Exception;
 using USFB;
+using Zenject;
 
 namespace Assets.Scripts.System
 {
@@ -74,7 +71,7 @@ namespace Assets.Scripts.System
                 foreach (var path in betaSceneDirectoryPaths)
                 {
                     var sceneDirectoryState = LoadSceneDirectoryState(path);
-                    
+
                     if (!sceneManagerState.TryGetDirectoryState(sceneDirectoryState.directoryPath, out sceneDirectoryState))
                     {
                         sceneManagerState.AddSceneDirectoryState(sceneDirectoryState);
@@ -89,7 +86,7 @@ namespace Assets.Scripts.System
                 var sceneDirectoryState = doAlphaFilesExist
                     ? new SceneDirectoryState(null, Guid.NewGuid(), DclEditVersion.Alpha)
                     : SceneDirectoryState.CreateNewSceneDirectoryState();
-                
+
                 //Don't have to check for duplicates since non existing / alpha scenes get converted.
                 sceneManagerState.AddSceneDirectoryState(sceneDirectoryState);
             }
@@ -322,29 +319,8 @@ namespace Assets.Scripts.System
         /// <returns>The new loaded scene.</returns>
         private SceneDirectoryState LoadSceneDirectoryState(string path)
         {
-            var sceneFileJson = Path.Combine(path, "scene.json");
-
-            SceneFileContents sceneFileContents;
-            try
-            {
-                sceneFileContents = JsonConvert.DeserializeObject<SceneFileContents>(sceneFileJson);
-            }
-            catch (Exception)
-            {
-                sceneFileContents = new SceneFileContents
-                {
-                    id = Guid.Empty,
-                    relativePath = path,
-                    settings = new JObject()
-                };
-            }
-
-            if (sceneFileContents.id == Guid.Empty)
-            {
-                sceneFileContents.id = Guid.NewGuid();
-            }
-
-            SceneDirectoryState sceneDirectoryState = new SceneDirectoryState(sceneFileContents.relativePath, sceneFileContents.id, DclEditVersion.Beta);
+            SceneDirectoryState sceneDirectoryState = new SceneDirectoryState(path, Guid.NewGuid());
+            sceneLoadSystem.Load(sceneDirectoryState);
             sceneManagerState.AddSceneDirectoryState(sceneDirectoryState);
             return sceneDirectoryState;
         }
@@ -361,12 +337,13 @@ namespace Assets.Scripts.System
             menuBarSystem.AddMenuItem("File/Save Scene", SaveCurrentScene);
             menuBarSystem.AddMenuItem("File/Save Scene As...", SaveCurrentSceneAs);
         }
-        
-        private struct SceneFileContents
+
+        public struct SceneFileContents
         {
             public Guid id;
             public string relativePath;
             public JObject settings;
+            public DclEditVersion dclEditVersion;
         }
     }
 }

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -21,6 +21,7 @@ namespace Assets.Scripts.System
         private IPathState pathState;
         private ISceneLoadSystem sceneLoadSystem;
         private ISceneSaveSystem sceneSaveSystem;
+        private SceneSettingState sceneSettingState;
         private CheckVersionSystem checkVersionSystem;
         private WorkspaceSaveSystem workspaceSaveSystem;
         private TypeScriptGenerationSystem typeScriptGenerationSystem;
@@ -33,6 +34,7 @@ namespace Assets.Scripts.System
             IPathState pathState,
             ISceneLoadSystem sceneLoadSystem,
             ISceneSaveSystem sceneSaveSystem,
+            SceneSettingState sceneSettingState,
             CheckVersionSystem checkVersionSystem,
             WorkspaceSaveSystem workspaceSaveSystem,
             TypeScriptGenerationSystem typeScriptGenerationSystem,
@@ -43,6 +45,7 @@ namespace Assets.Scripts.System
             this.pathState = pathState;
             this.sceneLoadSystem = sceneLoadSystem;
             this.sceneSaveSystem = sceneSaveSystem;
+            this.sceneSettingState = sceneSettingState;
             this.checkVersionSystem = checkVersionSystem;
             this.workspaceSaveSystem = workspaceSaveSystem;
             this.typeScriptGenerationSystem = typeScriptGenerationSystem;
@@ -186,6 +189,7 @@ namespace Assets.Scripts.System
             {
                 sceneSaveSystem.Save(sceneDirectoryState);
                 workspaceSaveSystem.Save(); // TODO: Save the workspace under proper conditions.
+                sceneSettingState.SaveSettings();
                 typeScriptGenerationSystem.GenerateTypeScript();
             }
         }

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -18,8 +18,9 @@ namespace Assets.Scripts.System
     {
         // Dependencies
         private SceneManagerState sceneManagerState;
-        private PathState pathState;
-        private SceneLoadSaveSystem sceneLoadSaveSystem;
+        private IPathState pathState;
+        private ISceneLoadSystem sceneLoadSystem;
+        private ISceneSaveSystem sceneSaveSystem;
         private CheckVersionSystem checkVersionSystem;
         private WorkspaceSaveSystem workspaceSaveSystem;
         private TypeScriptGenerationSystem typeScriptGenerationSystem;
@@ -29,8 +30,9 @@ namespace Assets.Scripts.System
         [Inject]
         public void Construct(
             SceneManagerState sceneManagerState,
-            PathState pathState,
-            SceneLoadSaveSystem sceneLoadSaveSystem,
+            IPathState pathState,
+            ISceneLoadSystem sceneLoadSystem,
+            ISceneSaveSystem sceneSaveSystem,
             CheckVersionSystem checkVersionSystem,
             WorkspaceSaveSystem workspaceSaveSystem,
             TypeScriptGenerationSystem typeScriptGenerationSystem,
@@ -39,7 +41,8 @@ namespace Assets.Scripts.System
         {
             this.sceneManagerState = sceneManagerState;
             this.pathState = pathState;
-            this.sceneLoadSaveSystem = sceneLoadSaveSystem;
+            this.sceneLoadSystem = sceneLoadSystem;
+            this.sceneSaveSystem = sceneSaveSystem;
             this.checkVersionSystem = checkVersionSystem;
             this.workspaceSaveSystem = workspaceSaveSystem;
             this.typeScriptGenerationSystem = typeScriptGenerationSystem;
@@ -181,7 +184,7 @@ namespace Assets.Scripts.System
             }
             else
             {
-                sceneLoadSaveSystem.Save(sceneDirectoryState);
+                sceneSaveSystem.Save(sceneDirectoryState);
                 workspaceSaveSystem.Save(); // TODO: Save the workspace under proper conditions.
                 typeScriptGenerationSystem.GenerateTypeScript();
             }
@@ -296,12 +299,12 @@ namespace Assets.Scripts.System
             switch (sceneDirectoryState.dclEditVersion)
             {
                 case DclEditVersion.Alpha:
-                    sceneLoadSaveSystem.LoadV1(sceneDirectoryState);
+                    sceneLoadSystem.LoadV1(sceneDirectoryState);
                     break;
                 case DclEditVersion.Beta:
                     //TODO Implement a version check (i.e. 2.0)
                     //TODO Display a message, that the user should update dcl-edit and exit after user input 
-                    sceneLoadSaveSystem.Load(sceneDirectoryState);
+                    sceneLoadSystem.Load(sceneDirectoryState);
                     break;
                 default:
                     throw new ArgumentException("Scene directory state is neither alpha nor beta");

--- a/Assets/Scripts/System/TypeScriptGenerationSystem.cs
+++ b/Assets/Scripts/System/TypeScriptGenerationSystem.cs
@@ -113,9 +113,9 @@ namespace Assets.Scripts.System
 
         private GenerationInfo? GatherInfo()
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            SceneDirectoryState sceneDirectoryState = sceneManagerSystem.GetCurrentDirectoryState();
 
-            if (scene == null)
+            if (sceneDirectoryState.currentScene == null)
             {
                 return null;
             }
@@ -132,11 +132,11 @@ namespace Assets.Scripts.System
 
                 var sceneInfo = new SceneInfo()
                 {
-                    symbol = exposeEntitySystem.GenerateValidSymbol(scene.name),
+                    symbol = exposeEntitySystem.GenerateValidSymbol(sceneDirectoryState.name),
                     gatheredEntityInfos = new List<EntityInfo>()
                 };
 
-                foreach (var entity in scene.AllEntities.Select(pair => pair.Value))
+                foreach (var entity in sceneDirectoryState.currentScene.AllEntities.Select(pair => pair.Value))
                 {
                     var internalEntitySymbol = exposeEntitySystem.GenerateValidSymbol(obfuscate ? "e" : entity.CustomName);
 

--- a/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
+++ b/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
@@ -27,7 +27,7 @@ namespace Assets.Scripts.Tests.EditModeTests
 
             Assert.NotNull(scene);
 
-            Assert.AreEqual("New Scene", scene.name);
+            Assert.AreEqual("New Scene", sceneDirectoryState.name);
             Assert.AreEqual(2, scene.AllEntities.Count());
 
             var cubeEnt = scene.GetEntityById(Guid.Parse("733338c0-c576-4465-975b-248e9e5e7b63"));

--- a/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
+++ b/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
@@ -15,7 +15,7 @@ namespace Assets.Scripts.Tests.EditModeTests
         public void LoadScene()
         {
             var pathState = new MockPathState("simple-load-test");
-            var loadSaveSystem = new SceneLoadSaveSystem(pathState);
+            var loadSaveSystem = new SceneLoadSaveSystem();
             var sceneDirectoryState = new SceneDirectoryState();
             var scenePath = pathState.ProjectPath + "/dcl-edit/saves/v2/New Scene.dclscene";
 
@@ -62,8 +62,8 @@ namespace Assets.Scripts.Tests.EditModeTests
         [Test]
         public void LoadedFilePaths()
         {
-            var pathState = new MockPathState("simple-load-test", true);
-            var loadSaveSystem = new SceneLoadSaveSystem(pathState);
+            MockPathState pathState = new MockPathState("simple-load-test", true);
+            SceneLoadSaveSystem loadSaveSystem = new SceneLoadSaveSystem();
             var scenePath = pathState.ProjectPath + "/dcl-edit/saves/v2/New Scene.dclscene";
 
             // Load scene, add a entity, save, remove a entity, and save again. This should result in the original scene

--- a/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
+++ b/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
@@ -1,10 +1,11 @@
-using System;
-using System.Linq;
 using Assets.Scripts.EditorState;
+using Assets.Scripts.Events;
 using Assets.Scripts.SceneState;
 using Assets.Scripts.System;
 using Assets.Scripts.Tests.EditModeTests.TestUtility;
 using NUnit.Framework;
+using System;
+using System.Linq;
 using UnityEngine;
 
 namespace Assets.Scripts.Tests.EditModeTests
@@ -28,6 +29,7 @@ namespace Assets.Scripts.Tests.EditModeTests
             Assert.NotNull(scene);
 
             Assert.AreEqual("New Scene", sceneDirectoryState.name);
+            Assert.AreEqual(sceneDirectoryState.id, Guid.Parse("e8cafbb9-54f5-4064-8982-6cf86db3506a"));
             Assert.AreEqual(2, scene.AllEntities.Count());
 
             var cubeEnt = scene.GetEntityById(Guid.Parse("733338c0-c576-4465-975b-248e9e5e7b63"));
@@ -62,8 +64,33 @@ namespace Assets.Scripts.Tests.EditModeTests
         [Test]
         public void LoadedFilePaths()
         {
+            SceneManagerState sceneManagerState = new SceneManagerState();
             MockPathState pathState = new MockPathState("simple-load-test", true);
             SceneLoadSaveSystem loadSaveSystem = new SceneLoadSaveSystem();
+            SceneSettingState sceneSettingState = new SceneSettingState();
+            CheckVersionSystem checkVersionSystem = new CheckVersionSystem();
+            WorkspaceSaveSystem workspaceSaveSystem = new WorkspaceSaveSystem();
+            TypeScriptGenerationSystem typeScriptGenerationSystem = new TypeScriptGenerationSystem();
+            SceneViewSystem sceneViewSystem = new SceneViewSystem();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            SceneManagerSystem sceneManagerSystem = new SceneManagerSystem();
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+
+            menuBarSystem.Construct(editorEvents, menuBarState);
+            sceneSettingState.Construct(pathState, sceneManagerState);
+            sceneManagerSystem.Construct(
+                sceneManagerState,
+                pathState,
+                loadSaveSystem,
+                loadSaveSystem,
+                sceneSettingState,
+                checkVersionSystem,
+                workspaceSaveSystem,
+                typeScriptGenerationSystem,
+                sceneViewSystem,
+                menuBarSystem);
+
             var scenePath = pathState.ProjectPath + "/dcl-edit/saves/v2/New Scene.dclscene";
 
             // Load scene, add a entity, save, remove a entity, and save again. This should result in the original scene
@@ -120,6 +147,69 @@ namespace Assets.Scripts.Tests.EditModeTests
                 var newEntity = scene.GetEntityById(newEntityId);
                 Assert.Null(newEntity);
             }
+        }
+
+        [Test]
+        public void SaveScene()
+        {
+            // Setup dependencies
+            var pathState = new MockPathState("simple-load-test", true);
+            var loadSaveSystem = new SceneLoadSaveSystem();
+
+            // Create scene directory state
+            string scenePath = pathState.ProjectPath + "/dcl-edit/saves/v2/New Scene.dclscene";
+            Guid sceneId = Guid.NewGuid();
+            SceneDirectoryState sceneDirectoryState = new SceneDirectoryState(scenePath, sceneId);
+
+            // Load scene from testing repository
+            loadSaveSystem.Load(sceneDirectoryState);
+
+            // Change scene ID
+            sceneDirectoryState.id = sceneId;
+
+            // Change names of existing entities
+            DclEntity cube = sceneDirectoryState.currentScene.GetEntityById(Guid.Parse("733338c0-c576-4465-975b-248e9e5e7b63"));
+            cube.CustomName = "Default Cube Renamed";
+            DclEntity sphere = sceneDirectoryState.currentScene.GetEntityById(Guid.Parse("84089323-69df-4d27-b0da-a51afcdd88bf"));
+            sphere.CustomName = "Default Sphere Renamed";
+
+            // Create new entities
+            Guid entity1Id = Guid.NewGuid();
+            Guid entity2Id = Guid.NewGuid();
+            DclEntity entity1 = new DclEntity(entity1Id, "Entity1");
+            DclEntity entity2 = new DclEntity(entity2Id, "Entity2");
+
+            // Add new entities to scene
+            sceneDirectoryState.currentScene.AddEntity(entity1);
+            sceneDirectoryState.currentScene.AddEntity(entity2);
+
+            // Save to filesystem
+            loadSaveSystem.Save(sceneDirectoryState);
+
+            // Load from filesystem
+            SceneDirectoryState loadedSceneDirectoryState = new SceneDirectoryState(scenePath, Guid.NewGuid());
+            loadSaveSystem.Load(loadedSceneDirectoryState);
+
+            // Run tests
+            Assert.AreEqual(loadedSceneDirectoryState.id, sceneId);
+            Assert.AreEqual(loadedSceneDirectoryState.name, "New Scene");
+            Assert.NotNull(loadedSceneDirectoryState.currentScene);
+            DclEntity loadedEntity1 = loadedSceneDirectoryState.currentScene.GetEntityById(entity1Id);
+            Assert.NotNull(loadedEntity1);
+            Assert.AreEqual(loadedEntity1.Id, entity1Id);
+            Assert.AreEqual(loadedEntity1.CustomName, "Entity1");
+            DclEntity loadedEntity2 = loadedSceneDirectoryState.currentScene.GetEntityById(entity2Id);
+            Assert.NotNull(loadedEntity2);
+            Assert.AreEqual(loadedEntity2.Id, entity2Id);
+            Assert.AreEqual(loadedEntity2.CustomName, "Entity2");
+            DclEntity loadedCube = loadedSceneDirectoryState.currentScene.GetEntityById(Guid.Parse("733338c0-c576-4465-975b-248e9e5e7b63"));
+            Assert.NotNull(loadedCube);
+            Assert.AreEqual(loadedCube.Id, Guid.Parse("733338c0-c576-4465-975b-248e9e5e7b63"));
+            Assert.AreEqual(loadedCube.CustomName, "Default Cube Renamed");
+            DclEntity loadedSphere = loadedSceneDirectoryState.currentScene.GetEntityById(Guid.Parse("84089323-69df-4d27-b0da-a51afcdd88bf"));
+            Assert.NotNull(loadedSphere);
+            Assert.AreEqual(loadedSphere.Id, Guid.Parse("84089323-69df-4d27-b0da-a51afcdd88bf"));
+            Assert.AreEqual(loadedSphere.CustomName, "Default Sphere Renamed");
         }
     }
 }


### PR DESCRIPTION
- Scene metadata such as the scene ID is gets saved into the scene.json file inside of the project folder. 
- The way the SceneManagerSystem handles saving and loading was updated: now only the injected ISceneSaveSystem and ISceneLoadSystem are responsible for the saving/loading process