### PR TITLE
Ref/feature/undo menu bar

### DIFF
--- a/Assets/Scripts/EditorState/ContextMenuState.cs
+++ b/Assets/Scripts/EditorState/ContextMenuState.cs
@@ -31,19 +31,46 @@ namespace Assets.Scripts.EditorState
                 Left,
                 Right
             }
-            public Direction expandDirection;               // Which direction should the menu expand to when placed at this position.
+            public Direction expandDirection; // Which direction should the menu expand to when placed at this position.
             public Vector3 position;
+        }
+
+        /// <summary>
+        /// Sort all the items in the context menu and all sub menues by their sortingPriotiry.
+        /// </summary>
+        /// <param name="items">The context menu to sort.</param>
+        public static void SortItems(List<ContextMenuItem> items)
+        {
+            items.Sort(delegate (ContextMenuItem itemX, ContextMenuItem itemY) { return itemX.sortingPriotiry.CompareTo(itemY.sortingPriotiry); });
+
+            // sort sub menu recursively
+            foreach (var item in items)
+            {
+                if (item is ContextSubmenuItem)
+                {
+                    SortItems(((ContextSubmenuItem)item).items);
+                }
+            }
         }
     }
 
-    public abstract class ContextMenuItem { }
+    public abstract class ContextMenuItem
+    {
+        public int sortingPriotiry = 0;
+
+        public ContextMenuItem(int sortingPriority = 0)
+        {
+            this.sortingPriotiry = sortingPriority;
+        }
+    }
+
     public class ContextSubmenuItem : ContextMenuItem
     {
         public Guid submenuId;
         public string title;
         public List<ContextMenuItem> items;
 
-        public ContextSubmenuItem(string title, List<ContextMenuItem> subItems = null)
+        public ContextSubmenuItem(string title, List<ContextMenuItem> subItems = null, int sortingPriority = 0) : base(sortingPriority)
         {
             this.submenuId = Guid.NewGuid();
             this.title = title;
@@ -63,12 +90,16 @@ namespace Assets.Scripts.EditorState
         public UnityAction onClick;
         public bool isDisabled;
 
-        public ContextMenuTextItem(string title, UnityAction onClick, bool isDisabled = false)
+        public ContextMenuTextItem(string title, UnityAction onClick, bool isDisabled = false, int sortingPriority = 0) : base(sortingPriority)
         {
             this.title = title;
             this.onClick = onClick;
             this.isDisabled = isDisabled;
         }
     }
-    public class ContextMenuSpacerItem : ContextMenuItem { }
+    public class ContextMenuSpacerItem : ContextMenuItem
+    {
+        public ContextMenuSpacerItem(int sortingPriority = 0) : base(sortingPriority)
+        { }
+    }
 }

--- a/Assets/Scripts/EditorState/ContextMenuState.cs
+++ b/Assets/Scripts/EditorState/ContextMenuState.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Events;
 
@@ -37,11 +38,16 @@ namespace Assets.Scripts.EditorState
 
         /// <summary>
         /// Sort all the items in the context menu and all sub menues by their sortingPriotiry.
+        /// The Sort is stable, so elements with the same sorting priority stay in order.
         /// </summary>
         /// <param name="items">The context menu to sort.</param>
         public static void SortItems(List<ContextMenuItem> items)
         {
-            items.Sort(delegate (ContextMenuItem itemX, ContextMenuItem itemY) { return itemX.sortingPriotiry.CompareTo(itemY.sortingPriotiry); });
+            // use System.Linq.OrderBy sorting because it is stable unlike the System.Collections.Generic.Sort.
+            List<ContextMenuItem>  itemsSorted = items.OrderBy(item => item.sortingPriotiry).ToList();
+            // inset sorted items into the original list, so the reference to the list does not change.
+            items.Clear();
+            items.AddRange(itemsSorted);
 
             // sort sub menu recursively
             foreach (var item in items)

--- a/Assets/Scripts/EditorState/MenuBarState.cs
+++ b/Assets/Scripts/EditorState/MenuBarState.cs
@@ -78,7 +78,6 @@ namespace Assets.Scripts.EditorState
             if (path.Depth == 1)
             {
                 AddToNewContextMenuItems(items, path, onClick);
-                ContextMenuState.SortItems(items);
             }
             else
             {
@@ -98,7 +97,6 @@ namespace Assets.Scripts.EditorState
                 {
                     // switch to adding items
                     AddToNewContextMenuItems(items, path, onClick);
-                    ContextMenuState.SortItems(items);
                 }
             }
         }

--- a/Assets/Scripts/EditorState/MenuBarState.cs
+++ b/Assets/Scripts/EditorState/MenuBarState.cs
@@ -10,7 +10,7 @@ namespace Assets.Scripts.EditorState
 {
     public class MenuBarState
     {
-        public List<MenuBarItem> menuItems = new List<MenuBarItem>(); //wish to be Lis<MenuBarItem>
+        public List<MenuBarItem> menuItems = new List<MenuBarItem>();
 
         public class MenuBarItem : ContextMenuItem
         {
@@ -30,35 +30,24 @@ namespace Assets.Scripts.EditorState
             }
         }
 
-        public void AddMenuItem(string path, UnityAction onClick, int position = -1)
+        public void AddMenuItem(string path, UnityAction onClick)
         {
-            // Check for root directory.
-            if (path.IndexOf('/') < 0)
-            {
-                Debug.LogError($"Cannot add actions to the root of the menu bar. Create at least one directory like \"File/My Action\".");
-            }
-
-            // Check for nameless directories.
-            foreach (string pathPart in path.Split('/'))
-            {
-                if (pathPart == "")
-                {
-                    Debug.LogError($"Unvalid Path for adding to menu bar: \"{path}\".");
-                    return;
-                }
-            }
-
             // Check for null action.
             if (onClick == null)
             {
-                Debug.LogError("Null cannot be added to the menu bar items.");
-                return;
+                throw new System.ArgumentException($"Null not a valid onClick argument.");
             }
 
-            (string pathPartFirst, string pathPartSub) = SplitPath(path);
+            Path pathParsed = new Path(path);
 
-            MenuBarItem itemToAddTo = GetOrCreateMenuBarItem(pathPartFirst);
-            AddToExistingContextMenuItems(itemToAddTo.subItems, pathPartSub, onClick, position);
+            // Check for root directory.
+            if (pathParsed.Depth <= 1)
+            {
+                throw new System.ArgumentException($"Cannot add actions to the root of the menu bar. Create at least one directory. \"{path}\".");
+            }
+
+            MenuBarItem itemToAddTo = GetOrCreateMenuBarItem(pathParsed.FirstTitle);
+            AddToExistingContextMenuItems(itemToAddTo.subItems, pathParsed.FirstElementRemoved(), onClick);
         }
 
 
@@ -77,52 +66,49 @@ namespace Assets.Scripts.EditorState
         }
 
 
-        private void AddToExistingContextMenuItems(List<ContextMenuItem> items, string path, UnityAction onClick, int position)
+        private void AddToExistingContextMenuItems(List<ContextMenuItem> items, Path path, UnityAction onClick)
         {
-            if (path.IndexOf('/') < 0)
+            if (path.Depth == 1)
             {
-                AddToNewContextMenuItems(items, path, onClick, position);
+                AddToNewContextMenuItems(items, path, onClick);
             }
             else
             {
-                (string pathPartFirst, string pathPartSub) = SplitPath(path);
-
                 if (items == null)
                 {
                     Debug.Log(path);
                 }
 
-                ContextSubmenuItem foundItem = (ContextSubmenuItem)items.SingleOrDefault(item => (item as ContextSubmenuItem)?.title == pathPartFirst);
+                ContextSubmenuItem foundItem = (ContextSubmenuItem)items.SingleOrDefault(item => (item as ContextSubmenuItem)?.title == path.FirstTitle);
 
                 if (foundItem != null)
                 {
-                    //recursive
-                    AddToExistingContextMenuItems(foundItem.items, pathPartSub, onClick, position);
+                    // recursive
+                    AddToExistingContextMenuItems(foundItem.items, path.FirstElementRemoved(), onClick);
                 }
                 else
                 {
-                    //switch to adding items
-                    AddToNewContextMenuItems(items, path, onClick, position);
+                    // switch to adding items
+                    AddToNewContextMenuItems(items, path, onClick);
                 }
             }
         }
 
 
-        private void AddToNewContextMenuItems(List<ContextMenuItem> items, string path, UnityAction onClick, int position)
+        private void AddToNewContextMenuItems(List<ContextMenuItem> items, Path path, UnityAction onClick)
         {
-            while (path.IndexOf('/') > 0)
+            while (path.Depth > 1)
             {
-                (string pathPartFirst, string pathPartSub) = SplitPath(path);
-
-                ContextSubmenuItem newSubmenuItem = new ContextSubmenuItem(pathPartFirst);
+                ContextSubmenuItem newSubmenuItem = new ContextSubmenuItem(path.FirstTitle);
                 items.Add(newSubmenuItem);
 
                 items = newSubmenuItem.items;
-                path = pathPartSub;
+                path.RemoveFirstElement();
             }
 
-            ContextMenuTextItem newMenuTextItem = new ContextMenuTextItem(path, onClick);
+            ContextMenuTextItem newMenuTextItem = new ContextMenuTextItem(path.FirstTitle, onClick);
 
+            int position = path.FirstPositionIndex;
             if (position < 0 || position > items.Count)
             {
                 position = items.Count;
@@ -130,12 +116,126 @@ namespace Assets.Scripts.EditorState
             items.Insert(position, newMenuTextItem);
         }
 
-        private (string, string) SplitPath(string path)
+        /// <summary>
+        /// Used to extract atomic informations from paths for th emenu bar.
+        /// </summary>
+        private class Path
         {
-            string pathPartFirst = path.Substring(0, path.IndexOf('/')); //the first part of the path
-            string pathPartSub = path.Substring(path.IndexOf('/') + 1); //the path except the first part
+            private int firstElement; //used to skip elements, by just incrementing. Starting with 0.
+            private string[] titles;
+            private int[] positionIndices;
 
-            return (pathPartFirst, pathPartSub);
+            /// <summary>
+            /// The title of the first element of the path without its position index.
+            /// </summary>
+            public string FirstTitle { get => titles[firstElement]; }
+
+            /// <summary>
+            /// The position index of the first element of the path.
+            /// </summary>
+            public int FirstPositionIndex { get => positionIndices[firstElement]; } //the position index of the first element of the path
+
+            /// <summary>
+            /// The number of elements in th remaining path.
+            /// </summary>
+            public int Depth { get => titles.Length - firstElement; }
+
+
+            private Path(Path path)
+            {
+                firstElement = path.firstElement;
+                titles = path.titles;
+                positionIndices = path.positionIndices;
+            }
+
+            /// <summary>
+            /// Contert a string path to at Path object.
+            /// </summary>
+            /// <param name="path"></param>
+            public Path(string path)
+            {
+                firstElement = 0;
+                titles = path.Split('/');
+
+                // Check for empty titles.
+                foreach (string title in titles)
+                {
+                    if (title == "")
+                    {
+                        throw new System.ArgumentException($"Elements are not allowed to have no title: \"{path}\".");
+                    }
+                }
+
+                positionIndices = new int[titles.Length];
+
+                for (int i = 0; i < titles.Length; i++)
+                {
+                    int splitterIndex = titles[i].IndexOf('#');
+                    if (splitterIndex > 0)
+                    {
+                        try
+                        {
+                            positionIndices[i] = int.Parse(titles[i].Substring(splitterIndex + 1));
+                        }
+                        catch
+                        {
+                            throw new System.ArgumentException($"The position index \"{titles[i].Substring(splitterIndex)}\" is not valid. From the Path: \"{path}\".");
+                        }
+                        titles[i] = titles[i].Substring(0, splitterIndex);
+                    }
+                    else
+                    {
+                        positionIndices[i] = -1;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Remove the first element from the Path to use the rest of the path.
+            /// </summary>
+            /// <returns>This with all other elements.</returns>
+            /// <exception cref="System.Exception"></exception>
+            public Path RemoveFirstElement()
+            {
+                if (Depth <= 1)
+                {
+                    throw new System.Exception($"Cannot Remove any more elements the Path \"{ToString()}\".");
+                }
+                firstElement ++;
+
+                return this;
+            }
+
+            /// <summary>
+            /// Remove the first element from the Path to use the rest of the path.
+            /// </summary>
+            /// <returns>New Path object with all other elements.</returns>
+            /// <exception cref="System.Exception"></exception>
+            public Path FirstElementRemoved()
+            {
+                return new Path(this).RemoveFirstElement();
+            }
+
+            /// <summary>
+            /// Convert back to a string Path. Used for logging.
+            /// </summary>
+            /// <returns>The path as string.</returns>
+            public override string ToString()
+            {
+                string str = "";
+
+                for (int i = firstElement; i < titles.Length - 1; i++)
+                {
+                    str += titles[i];
+                    if (positionIndices[i] >= 0)
+                    {
+                        str += "#" + positionIndices[i];
+                    }
+                    str += "/";
+                }
+
+                return str;
+            }
         }
     }
 }

--- a/Assets/Scripts/System/CommandSystem.cs
+++ b/Assets/Scripts/System/CommandSystem.cs
@@ -10,16 +10,21 @@ namespace Assets.Scripts.System
         public CommandFactorySystem CommandFactory { get; private set; }
         private EditorEvents editorEvents;
         private SceneManagerSystem sceneManagerSystem;
+        private MenuBarSystem menuBarSystem;
 
         [Inject]
         public void Construct(
             CommandFactorySystem commandFactory,
             EditorEvents editorEvents,
-            SceneManagerSystem sceneManagerSystem)
+            SceneManagerSystem sceneManagerSystem,
+            MenuBarSystem menuBarSystem)
         {
             CommandFactory = commandFactory;
             this.editorEvents = editorEvents;
             this.sceneManagerSystem = sceneManagerSystem;
+            this.menuBarSystem = menuBarSystem;
+
+            CreateMenuBarItems();
         }
 
         public void ExecuteCommand<T>(T command) where T : SceneState.Command
@@ -79,6 +84,12 @@ namespace Assets.Scripts.System
                 commandState.CurrentCommandIndex++;
                 commandState.CommandHistory[commandState.CurrentCommandIndex].Do(sceneManagerSystem.GetCurrentScene(), editorEvents);
             }
+        }
+
+        private void CreateMenuBarItems()
+        {
+            menuBarSystem.AddMenuItem("Edit#2/Undo#1", UndoCommand);
+            menuBarSystem.AddMenuItem("Edit#2/Redo#2", RedoCommand);
         }
     }
 }

--- a/Assets/Scripts/System/ContextMenuSystem.cs
+++ b/Assets/Scripts/System/ContextMenuSystem.cs
@@ -42,12 +42,13 @@ namespace Assets.Scripts.System
         }
 
         /// <summary>
-        /// Open the given context menu.
+        /// Open the given context menu and sort all its items by their sorting priotiry.
         /// </summary>
         /// <param name="possiblePlacements">The Placement options for the context menu.</param>
         /// <param name="items">All the menu items for the context menu.</param>
         public void OpenMenu(List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
         {
+            ContextMenuState.SortItems(items);
             var data = new ContextMenuState.Data(Guid.NewGuid(), items, possiblePlacements);
             _state.menuData.Clear();
             _state.menuData.Push(data);
@@ -71,41 +72,6 @@ namespace Assets.Scripts.System
             var data = new ContextMenuState.Data(menuId, items, possiblePlacements);
             _state.menuData.Push(data);
             _editorEvents.InvokeUpdateContextMenuEvent();
-        }
-
-        /// <summary>
-        /// Open the given context menu and sort all its items by their sorting priotiry.
-        /// </summary>
-        /// <param name="position">The position used as origin for the context menu.</param>
-        /// <param name="items">All the menu items for the context menu.</param>
-        public void OpenMenuSorted(Vector3 position, List<ContextMenuItem> items)
-        {
-            ContextMenuState.SortItems(items);
-            OpenMenu(position, items);
-        }
-
-        /// <summary>
-        /// Open the given context menu and sort all its items by their sorting priotiry.
-        /// </summary>
-        /// <param name="possiblePlacements">The Placement options for the context menu.</param>
-        /// <param name="items">All the menu items for the context menu.</param>
-        public void OpenMenuSorted(List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
-        {
-            ContextMenuState.SortItems(items);
-            OpenMenu(possiblePlacements, items);
-        }
-
-
-        /// <summary>
-        /// Open the given context menu and sort all its items by their sorting priotiry.
-        /// </summary>
-        /// <param name="menuId">The submenu will have this id.</param>
-        /// <param name="possiblePlacements">The Placement options for the context menu.</param>
-        /// <param name="items">All the menu items for the context menu.</param>
-        public void OpenSubmenuSorted(Guid menuId, List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
-        {
-            ContextMenuState.SortItems(items);
-            OpenSubmenu(menuId, possiblePlacements, items);
         }
 
         public void CloseMenu()

--- a/Assets/Scripts/System/ContextMenuSystem.cs
+++ b/Assets/Scripts/System/ContextMenuSystem.cs
@@ -54,11 +54,11 @@ namespace Assets.Scripts.System
             _editorEvents.InvokeUpdateContextMenuEvent();
         }
 
-        //TODO: specify: <param name="menuId"></param>
+
         /// <summary>
         /// Open the given context menu.
         /// </summary>
-        /// <param name="menuId"></param>
+        /// <param name="menuId">The submenu will have this id.</param>
         /// <param name="possiblePlacements">The Placement options for the context menu.</param>
         /// <param name="items">All the menu items for the context menu.</param>
         public void OpenSubmenu(Guid menuId, List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
@@ -81,8 +81,7 @@ namespace Assets.Scripts.System
         public void OpenMenuSorted(Vector3 position, List<ContextMenuItem> items)
         {
             ContextMenuState.SortItems(items);
-
-            OpenMenuSorted(position, items);
+            OpenMenu(position, items);
         }
 
         /// <summary>
@@ -93,22 +92,20 @@ namespace Assets.Scripts.System
         public void OpenMenuSorted(List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
         {
             ContextMenuState.SortItems(items);
-
             OpenMenu(possiblePlacements, items);
         }
 
-        //TODO: specify: <param name="menuId"></param>
+
         /// <summary>
         /// Open the given context menu and sort all its items by their sorting priotiry.
         /// </summary>
-        /// <param name="menuId"></param>
+        /// <param name="menuId">The submenu will have this id.</param>
         /// <param name="possiblePlacements">The Placement options for the context menu.</param>
         /// <param name="items">All the menu items for the context menu.</param>
         public void OpenSubmenuSorted(Guid menuId, List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
         {
             ContextMenuState.SortItems(items);
-
-            OpenSubmenuSorted(menuId, possiblePlacements, items);
+            OpenSubmenu(menuId, possiblePlacements, items);
         }
 
         public void CloseMenu()

--- a/Assets/Scripts/System/ContextMenuSystem.cs
+++ b/Assets/Scripts/System/ContextMenuSystem.cs
@@ -30,11 +30,22 @@ namespace Assets.Scripts.System
             }
         }
 
+        /// <summary>
+        /// Open the given context menu.
+        /// </summary>
+        /// <param name="position">The position used as origin for the context menu.</param>
+        /// <param name="items">All the menu items for the context menu.</param>
         public void OpenMenu(Vector3 position, List<ContextMenuItem> items)
         {
             var placement = new ContextMenuState.Placement { expandDirection = ContextMenuState.Placement.Direction.Any, position = position };
             OpenMenu(new List<ContextMenuState.Placement> { placement }, items);
         }
+
+        /// <summary>
+        /// Open the given context menu.
+        /// </summary>
+        /// <param name="possiblePlacements">The Placement options for the context menu.</param>
+        /// <param name="items">All the menu items for the context menu.</param>
         public void OpenMenu(List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
         {
             var data = new ContextMenuState.Data(Guid.NewGuid(), items, possiblePlacements);
@@ -43,6 +54,13 @@ namespace Assets.Scripts.System
             _editorEvents.InvokeUpdateContextMenuEvent();
         }
 
+        //TODO: specify: <param name="menuId"></param>
+        /// <summary>
+        /// Open the given context menu.
+        /// </summary>
+        /// <param name="menuId"></param>
+        /// <param name="possiblePlacements">The Placement options for the context menu.</param>
+        /// <param name="items">All the menu items for the context menu.</param>
         public void OpenSubmenu(Guid menuId, List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
         {
             // Check if menu is already open
@@ -53,6 +71,44 @@ namespace Assets.Scripts.System
             var data = new ContextMenuState.Data(menuId, items, possiblePlacements);
             _state.menuData.Push(data);
             _editorEvents.InvokeUpdateContextMenuEvent();
+        }
+
+        /// <summary>
+        /// Open the given context menu and sort all its items by their sorting priotiry.
+        /// </summary>
+        /// <param name="position">The position used as origin for the context menu.</param>
+        /// <param name="items">All the menu items for the context menu.</param>
+        public void OpenMenuSorted(Vector3 position, List<ContextMenuItem> items)
+        {
+            ContextMenuState.SortItems(items);
+
+            OpenMenuSorted(position, items);
+        }
+
+        /// <summary>
+        /// Open the given context menu and sort all its items by their sorting priotiry.
+        /// </summary>
+        /// <param name="possiblePlacements">The Placement options for the context menu.</param>
+        /// <param name="items">All the menu items for the context menu.</param>
+        public void OpenMenuSorted(List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
+        {
+            ContextMenuState.SortItems(items);
+
+            OpenMenu(possiblePlacements, items);
+        }
+
+        //TODO: specify: <param name="menuId"></param>
+        /// <summary>
+        /// Open the given context menu and sort all its items by their sorting priotiry.
+        /// </summary>
+        /// <param name="menuId"></param>
+        /// <param name="possiblePlacements">The Placement options for the context menu.</param>
+        /// <param name="items">All the menu items for the context menu.</param>
+        public void OpenSubmenuSorted(Guid menuId, List<ContextMenuState.Placement> possiblePlacements, List<ContextMenuItem> items)
+        {
+            ContextMenuState.SortItems(items);
+
+            OpenSubmenuSorted(menuId, possiblePlacements, items);
         }
 
         public void CloseMenu()
@@ -67,7 +123,7 @@ namespace Assets.Scripts.System
         /// <param name="id"></param>
         public void CloseMenusUntil(Guid id)
         {
-            if (_state.menuData.Peek().menuId == id) { return; }               // Menu is already at the top
+            if (_state.menuData.Peek().menuId == id) { return; } // Menu is already at the top
             while (_state.menuData.Count > 0)
             {
                 if (_state.menuData.Peek().menuId == id) { break; }

--- a/Assets/Scripts/System/MenuBarSystem.cs
+++ b/Assets/Scripts/System/MenuBarSystem.cs
@@ -44,9 +44,9 @@ namespace Assets.Scripts.System
         /// <param name="path">The path to the Menu/Submenu of the entry (e.g. "File/Open/Project")</param>
         /// <param name="onClick">The Action called when the Entry (e.g. "Project") is clicked.</param>
         /// <param name="position">The Position to add in the lowest level. -1 to append as last.</param>
-        public void AddMenuItem(string path, UnityAction onClick, int position = -1)
+        public void AddMenuItem(string path, UnityAction onClick)
         {
-            _state.AddMenuItem(path, onClick, position);
+            _state.AddMenuItem(path, onClick);
             _editorEvents.InvokeUpdateMenuBarEvent();
         }
     }

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -349,10 +349,10 @@ namespace Assets.Scripts.System
 
         private void CreateMenuBarItems()
         {
-            menuBarSystem.AddMenuItem("File/New Scene", SetNewScneneAsCurrentScene);
-            menuBarSystem.AddMenuItem("File/Open Scene", SetDialogAsCurrentScene);
-            menuBarSystem.AddMenuItem("File/Save Scene", SaveCurrentScene);
-            menuBarSystem.AddMenuItem("File/Save Scene As...", SaveCurrentSceneAs);
+            menuBarSystem.AddMenuItem("File#1/New Scene#1", SetNewScneneAsCurrentScene);
+            menuBarSystem.AddMenuItem("File#1/Open Scene#2", SetDialogAsCurrentScene);
+            menuBarSystem.AddMenuItem("File#1/Save Scene#3", SaveCurrentScene);
+            menuBarSystem.AddMenuItem("File#1/Save Scene As...#4", SaveCurrentSceneAs);
         }
         
         private struct SceneFileContents

--- a/Assets/Scripts/Tests/EditModeTests/MenuBarSystemTest.cs
+++ b/Assets/Scripts/Tests/EditModeTests/MenuBarSystemTest.cs
@@ -29,7 +29,7 @@ namespace Assets.Scripts.Tests.EditModeTests
             ContextMenuItem contextMenuItem;
 
             //add menu item
-            menuBarSystem.AddMenuItem("A1/A2/A3", testUnityAction, -1);
+            menuBarSystem.AddMenuItem("A1/A2/A3", testUnityAction);
             CheckEventCounter(1);
 
             //asserts
@@ -47,7 +47,7 @@ namespace Assets.Scripts.Tests.EditModeTests
             Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
 
             //add menu item
-            menuBarSystem.AddMenuItem("A1/A2/A4", testUnityAction, -1);
+            menuBarSystem.AddMenuItem("A1/A2/A4", testUnityAction);
             CheckEventCounter(1);
 
             //asserts
@@ -65,7 +65,7 @@ namespace Assets.Scripts.Tests.EditModeTests
             Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
 
             //add menu item
-            menuBarSystem.AddMenuItem("A1/A2/A5", testUnityAction, 1);
+            menuBarSystem.AddMenuItem("A1/A2/A5#1", testUnityAction);
             CheckEventCounter(1);
 
             //asserts
@@ -83,7 +83,7 @@ namespace Assets.Scripts.Tests.EditModeTests
             Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
 
             //add menu item
-            menuBarSystem.AddMenuItem("A1/A6/A7", testUnityAction, 1);
+            menuBarSystem.AddMenuItem("A1/A6/A7", testUnityAction);
             CheckEventCounter(1);
 
             //asserts
@@ -116,7 +116,7 @@ namespace Assets.Scripts.Tests.EditModeTests
             UnityAction testUnityAction = new UnityAction(TestUnityAction);
 
             //add menu items
-            menuBarSystem.AddMenuItem("A1/A2/A3", testUnityAction, -1);
+            menuBarSystem.AddMenuItem("A1/A2/A3", testUnityAction);
             menuBarSystem.AddMenuItem("B1/B2", testUnityAction);
             menuBarSystem.AddMenuItem("B1/B3/B4", testUnityAction);
             menuBarSystem.AddMenuItem("B1/B3/B5", testUnityAction);

--- a/Assets/Scripts/Tests/EditModeTests/MenuBarSystemTest.cs
+++ b/Assets/Scripts/Tests/EditModeTests/MenuBarSystemTest.cs
@@ -13,101 +13,167 @@ namespace Assets.Scripts.Tests.EditModeTests
         int eventCounter;
 
         [Test]
-        public void TestMenuBarTreeA()
+        public void ExceptionMenuBarNullCallBack()
         {
             //construct system
-            MenuBarSystem menuBarSystem = new MenuBarSystem();
             EditorEvents editorEvents = new EditorEvents();
             MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            menuBarSystem.Construct(editorEvents, menuBarState);
+
+            Assert.Throws<ArgumentException>(() => { menuBarSystem.AddMenuItem("A1/A2/A3", null); });
+        }
+
+        [Test]
+        public void ExceptionMenuNoDepth()
+        {
+            //construct system
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            menuBarSystem.Construct(editorEvents, menuBarState);
+
+            Assert.Throws<ArgumentException>(() => { menuBarSystem.AddMenuItem("A1", TestUnityAction); });
+        }
+
+        [Test]
+        public void ExceptionMenuBarEmptyElement()
+        {
+            //construct system
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            menuBarSystem.Construct(editorEvents, menuBarState);
+
+            Assert.Throws<ArgumentException>(() => { menuBarSystem.AddMenuItem("A1//A3", TestUnityAction); });
+        }
+
+        [Test]
+        public void ExceptionMenuInvalid()
+        {
+            //construct system
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            menuBarSystem.Construct(editorEvents, menuBarState);
+
+            Assert.Throws<ArgumentException>(() => { menuBarSystem.AddMenuItem("A1/A2#1x/A3", TestUnityAction); });
+        }
+
+        [Test]
+        public void AddSimpleItem()
+        {
+            //construct system
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
             menuBarSystem.Construct(editorEvents, menuBarState);
 
             //prepare
             eventCounter = 0;
             editorEvents.onUpdateMenuBarEvent += CatchEvent;
             UnityAction testUnityAction = new UnityAction(TestUnityAction);
-            MenuBarState.MenuBarItem menuBarItem;
-            ContextMenuItem contextMenuItem;
 
-            //add menu item
-            menuBarSystem.AddMenuItem("A1/A2/A3", testUnityAction);
+            //add menu items
+            menuBarSystem.AddMenuItem("A1/A2", testUnityAction);
             CheckEventCounter(1);
 
             //asserts
-            Assert.AreEqual(menuBarState.menuItems.Count, 1);
-            menuBarItem = menuBarState.menuItems[0];
-            Assert.AreEqual(menuBarItem.title, "A1");
+            Assert.AreEqual(1, menuBarState.menuItems.Count);
 
-            Assert.AreEqual(menuBarItem.subItems.Count, 1);
-            contextMenuItem = menuBarItem.subItems[0];
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).title, "A2");
-
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).items.Count, 1);
-            contextMenuItem = (contextMenuItem as ContextSubmenuItem).items[0];
-            Assert.AreEqual((contextMenuItem as ContextMenuTextItem).title, "A3");
-            Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
-
-            //add menu item
-            menuBarSystem.AddMenuItem("A1/A2/A4", testUnityAction);
-            CheckEventCounter(1);
-
-            //asserts
-            Assert.AreEqual(menuBarState.menuItems.Count, 1);
-            menuBarItem = menuBarState.menuItems[0];
-            Assert.AreEqual(menuBarItem.title, "A1");
-
-            Assert.AreEqual(menuBarItem.subItems.Count, 1);
-            contextMenuItem = menuBarItem.subItems[0];
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).title, "A2");
-
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).items.Count, 2);
-            contextMenuItem = (contextMenuItem as ContextSubmenuItem).items[1];
-            Assert.AreEqual((contextMenuItem as ContextMenuTextItem).title, "A4");
-            Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
-
-            //add menu item
-            menuBarSystem.AddMenuItem("A1/A2/A5#1", testUnityAction);
-            CheckEventCounter(1);
-
-            //asserts
-            Assert.AreEqual(menuBarState.menuItems.Count, 1);
-            menuBarItem = menuBarState.menuItems[0];
-            Assert.AreEqual(menuBarItem.title, "A1");
-
-            Assert.AreEqual(menuBarItem.subItems.Count, 1);
-            contextMenuItem = menuBarItem.subItems[0];
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).title, "A2");
-
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).items.Count, 3);
-            contextMenuItem = (contextMenuItem as ContextSubmenuItem).items[1];
-            Assert.AreEqual((contextMenuItem as ContextMenuTextItem).title, "A5");
-            Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
-
-            //add menu item
-            menuBarSystem.AddMenuItem("A1/A6/A7", testUnityAction);
-            CheckEventCounter(1);
-
-            //asserts
-            Assert.AreEqual(menuBarState.menuItems.Count, 1);
-            menuBarItem = menuBarState.menuItems[0];
-            Assert.AreEqual(menuBarItem.title, "A1");
-
-            Assert.AreEqual(menuBarItem.subItems.Count, 2);
-            contextMenuItem = menuBarItem.subItems[1];
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).title, "A6");
-
-            Assert.AreEqual((contextMenuItem as ContextSubmenuItem).items.Count, 1);
-            contextMenuItem = (contextMenuItem as ContextSubmenuItem).items[0];
-            Assert.AreEqual((contextMenuItem as ContextMenuTextItem).title, "A7");
-            Assert.AreSame((contextMenuItem as ContextMenuTextItem).onClick, testUnityAction);
+            MenuBarState.MenuBarItem a1 = menuBarState.menuItems[0];
+            Assert.AreEqual("A1", a1.title);
+            ContextMenuTextItem a2 = a1.subItems[0] as ContextMenuTextItem;
+            Assert.AreEqual("A2", a2.title);
+            Assert.AreEqual(testUnityAction, a2.onClick);
         }
 
         [Test]
-        public void TestMenuBarTreeB()
+        public void AddDeepItem()
         {
             //construct system
-            MenuBarSystem menuBarSystem = new MenuBarSystem();
             EditorEvents editorEvents = new EditorEvents();
             MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            menuBarSystem.Construct(editorEvents, menuBarState);
+
+            //prepare
+            eventCounter = 0;
+            editorEvents.onUpdateMenuBarEvent += CatchEvent;
+            UnityAction testUnityAction = new UnityAction(TestUnityAction);
+
+            //add menu items
+            menuBarSystem.AddMenuItem("A1/A2/A3/A4/A5/A6", testUnityAction);
+            CheckEventCounter(1);
+
+            //asserts
+            Assert.AreEqual(1, menuBarState.menuItems.Count);
+            MenuBarState.MenuBarItem a1 = menuBarState.menuItems[0];
+            Assert.AreEqual("A1", a1.title);
+            ContextSubmenuItem a2 = a1.subItems[0] as ContextSubmenuItem;
+            Assert.AreEqual("A2", a2.title);
+            ContextSubmenuItem a3 = a2.items[0] as ContextSubmenuItem;
+            Assert.AreEqual("A3", a3.title);
+            ContextSubmenuItem a4 = a3.items[0] as ContextSubmenuItem;
+            Assert.AreEqual("A4", a4.title);
+            ContextSubmenuItem a5 = a4.items[0] as ContextSubmenuItem;
+            Assert.AreEqual("A5", a5.title);
+            ContextMenuTextItem a6 = a5.items[0] as ContextMenuTextItem;
+            Assert.AreEqual("A6", a6.title);
+        }
+
+        [Test]
+        public void AddItemsWithPriority()
+        {
+            //construct system
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
+            menuBarSystem.Construct(editorEvents, menuBarState);
+
+            //prepare
+            eventCounter = 0;
+            editorEvents.onUpdateMenuBarEvent += CatchEvent;
+            UnityAction testUnityAction = new UnityAction(TestUnityAction);
+
+            //add menu items
+            menuBarSystem.AddMenuItem("A1#5/A2#10", testUnityAction);
+            menuBarSystem.AddMenuItem("A1#5/A3#9", testUnityAction);
+            menuBarSystem.AddMenuItem("A1#5/A4#11", testUnityAction);
+            menuBarSystem.AddMenuItem("B1#-10/B2", testUnityAction);
+            menuBarSystem.AddMenuItem("C1#10/C2", testUnityAction);
+            CheckEventCounter(5);
+
+            //asserts
+            Assert.AreEqual(3, menuBarState.menuItems.Count);
+
+            MenuBarState.MenuBarItem a1 = menuBarState.menuItems[1];
+            Assert.AreEqual("A1", a1.title);
+            ContextMenuTextItem a2 = a1.subItems[1] as ContextMenuTextItem;
+            Assert.AreEqual("A2", a2.title);
+            ContextMenuTextItem a3 = a1.subItems[0] as ContextMenuTextItem;
+            Assert.AreEqual("A3", a3.title);
+            ContextMenuTextItem a4 = a1.subItems[2] as ContextMenuTextItem;
+            Assert.AreEqual("A4", a4.title);
+
+            MenuBarState.MenuBarItem b1 = menuBarState.menuItems[0];
+            Assert.AreEqual("B1", b1.title);
+            ContextMenuTextItem b2 = b1.subItems[0] as ContextMenuTextItem;
+            Assert.AreEqual("B2", b2.title);
+
+            MenuBarState.MenuBarItem c1 = menuBarState.menuItems[2];
+            Assert.AreEqual("C1", c1.title);
+            ContextMenuTextItem c2 = c1.subItems[0] as ContextMenuTextItem;
+            Assert.AreEqual("C2", c2.title);
+        }
+
+        [Test]
+        public void TestMenuBarTree()
+        {
+            //construct system
+            EditorEvents editorEvents = new EditorEvents();
+            MenuBarState menuBarState = new MenuBarState();
+            MenuBarSystem menuBarSystem = new MenuBarSystem();
             menuBarSystem.Construct(editorEvents, menuBarState);
 
             //prepare
@@ -124,23 +190,27 @@ namespace Assets.Scripts.Tests.EditModeTests
             CheckEventCounter(5);
 
             //asserts
-            Assert.AreEqual(menuBarState.menuItems.Count, 2);
+            Assert.AreEqual(2, menuBarState.menuItems.Count);
+
+            MenuBarState.MenuBarItem a1 = menuBarState.menuItems[0];
+            Assert.AreEqual("A1", a1.title);
+            ContextSubmenuItem a2 = a1.subItems[0] as ContextSubmenuItem;
+            Assert.AreEqual("A2", a2.title);
+            ContextMenuTextItem a3 = a2.items[0] as ContextMenuTextItem;
+            Assert.AreEqual("A3", a3.title);
+
             MenuBarState.MenuBarItem b1 = menuBarState.menuItems[1];
-            Assert.AreEqual(b1.title, "B1");
-
-            Assert.AreEqual(b1.subItems.Count, 3);
-            Assert.AreEqual((b1.subItems[0] as ContextMenuTextItem).title, "B2");
-            Assert.AreEqual((b1.subItems[0] as ContextMenuTextItem).onClick, testUnityAction);
-            Assert.AreEqual((b1.subItems[1] as ContextSubmenuItem).title, "B3");
-            Assert.AreEqual((b1.subItems[2] as ContextMenuTextItem).title, "B6");
-            Assert.AreEqual((b1.subItems[2] as ContextMenuTextItem).onClick, testUnityAction);
-
+            Assert.AreEqual("B1", b1.title);
+            ContextMenuTextItem b2 = b1.subItems[0] as ContextMenuTextItem;
+            Assert.AreEqual("B2", b2.title);
             ContextSubmenuItem b3 = b1.subItems[1] as ContextSubmenuItem;
-            Assert.AreEqual(b3.items.Count, 2);
-            Assert.AreEqual((b3.items[0] as ContextMenuTextItem).title, "B4");
-            Assert.AreEqual((b3.items[0] as ContextMenuTextItem).onClick, testUnityAction);
-            Assert.AreEqual((b3.items[1] as ContextMenuTextItem).title, "B5");
-            Assert.AreEqual((b3.items[1] as ContextMenuTextItem).onClick, testUnityAction);
+            Assert.AreEqual("B3", b3.title);
+            ContextMenuTextItem b4 = b3.items[0] as ContextMenuTextItem;
+            Assert.AreEqual("B4", b4.title);
+            ContextMenuTextItem b5 = b3.items[1] as ContextMenuTextItem;
+            Assert.AreEqual("B5", b5.title);
+            ContextMenuTextItem b6 = b1.subItems[2] as ContextMenuTextItem;
+            Assert.AreEqual("B6", b6.title);
         }
 
         //utility


### PR DESCRIPTION
Add `Undo` and `Redo` to the menu bar.

To achieve this, multiple changes were made:
- Merge the position index of the menu bar system into the path to be able to give each path element its index.
- Add sorting to the context menu system. This allows the implementation of the following step.
- replace position index with sorting order. The position index was relative to the number of already existing items, which was dependent on the order of execution. Now it's relative to their sorting order values.
- Finally, add the `Undo` and `Redo` items.