### PR TITLE
fix disable full-screen mode

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -100,8 +100,8 @@ PlayerSettings:
   xboxEnableKinectAutoTracking: 0
   xboxEnableFitness: 0
   visibleInBackground: 1
-  allowFullscreenSwitch: 1
-  fullscreenMode: 2
+  allowFullscreenSwitch: 0
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
Fullscreenmode 'Maximized Window' results in full-screen on any platform other than MaxOS. Therefore, 'Windowed' is used for now. Also disallow switching to full-screen.
https://docs.unity3d.com/ScriptReference/FullScreenMode.MaximizedWindow.html