### PR TITLE
open last opened scene on start up

### DIFF
--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -24,6 +24,7 @@ namespace Assets.Scripts.System
         private TypeScriptGenerationSystem typeScriptGenerationSystem;
         private SceneViewSystem sceneViewSystem;
         private MenuBarSystem menuBarSystem;
+        private SettingsSystem settingsSystem;
 
         [Inject]
         public void Construct(
@@ -36,7 +37,8 @@ namespace Assets.Scripts.System
             WorkspaceSaveSystem workspaceSaveSystem,
             TypeScriptGenerationSystem typeScriptGenerationSystem,
             SceneViewSystem sceneViewSystem,
-            MenuBarSystem menuBarSystem)
+            MenuBarSystem menuBarSystem,
+            SettingsSystem settingsSystem)
         {
             this.sceneManagerState = sceneManagerState;
             this.pathState = pathState;
@@ -48,7 +50,7 @@ namespace Assets.Scripts.System
             this.typeScriptGenerationSystem = typeScriptGenerationSystem;
             this.sceneViewSystem = sceneViewSystem;
             this.menuBarSystem = menuBarSystem;
-
+            this.settingsSystem = settingsSystem;
             CreateMenuBarItems();
         }
 
@@ -104,24 +106,17 @@ namespace Assets.Scripts.System
         /// <summary>
         /// Set last opened scene on start up
         /// </summary>
-        public void SetLastOpenedSceneAsCurrentScene(SettingsSystem.StringUserSetting openLastOpenedScene)
+        public void SetLastOpenedSceneAsCurrentScene()
         {
             Guid lastSceneIndex;
 
-            if (Guid.TryParse(openLastOpenedScene.Get(), out lastSceneIndex))
+            if (Guid.TryParse(settingsSystem.openLastOpenedScene.Get(), out lastSceneIndex))
             {
-                var lastSceneDirectoryState = new SceneDirectoryState(null, lastSceneIndex, DclEditVersion.Alpha);
-                sceneManagerState.AddSceneDirectoryState(lastSceneDirectoryState);
-                //SaveCurrentScene();
-                SaveScene(lastSceneDirectoryState);
                 SetCurrentScene(lastSceneIndex);
-                openLastOpenedScene.Set(lastSceneIndex.ToString());
             }
             else if (lastSceneIndex == Guid.Empty)
             {
                 SetNewSceneAsCurrentScene();
-                var newSceneIndex = sceneManagerState.currentSceneIndex;
-                openLastOpenedScene.Set(newSceneIndex.ToString());
             }
         }
 
@@ -170,6 +165,8 @@ namespace Assets.Scripts.System
         {
             sceneManagerState.SetCurrentSceneIndex(id);
             sceneViewSystem.SetUpCurrentScene();
+            var newSceneIndex = sceneManagerState.currentSceneIndex;
+            settingsSystem.openLastOpenedScene.Set(newSceneIndex.ToString());
         }
 
         /// <summary>

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -102,6 +102,19 @@ namespace Assets.Scripts.System
         }
 
         /// <summary>
+        /// Set last opened scene on start up
+        /// </summary>
+        public void SetLastOpenedSceneAsCurrentScene(int value)
+        {
+            if (value == 1)
+            {
+                Debug.Log("Setting last opened scene");
+                return;
+            }
+            Debug.Log("No last opened scene loaded");
+        }
+
+        /// <summary>
         /// Create a new scene and set it as current scene
         /// </summary>
         public void SetNewScneneAsCurrentScene()

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -104,20 +104,31 @@ namespace Assets.Scripts.System
         /// <summary>
         /// Set last opened scene on start up
         /// </summary>
-        public void SetLastOpenedSceneAsCurrentScene(int value)
+        public void SetLastOpenedSceneAsCurrentScene(SettingsSystem.StringUserSetting openLastOpenedScene)
         {
-            if (value == 1)
+            Guid lastSceneIndex;
+
+            if (Guid.TryParse(openLastOpenedScene.Get(), out lastSceneIndex))
             {
-                Debug.Log("Setting last opened scene");
-                return;
+                var lastSceneDirectoryState = new SceneDirectoryState(null, lastSceneIndex, DclEditVersion.Alpha);
+                sceneManagerState.AddSceneDirectoryState(lastSceneDirectoryState);
+                //SaveCurrentScene();
+                SaveScene(lastSceneDirectoryState);
+                SetCurrentScene(lastSceneIndex);
+                openLastOpenedScene.Set(lastSceneIndex.ToString());
             }
-            Debug.Log("No last opened scene loaded");
+            else if (lastSceneIndex == Guid.Empty)
+            {
+                SetNewSceneAsCurrentScene();
+                var newSceneIndex = sceneManagerState.currentSceneIndex;
+                openLastOpenedScene.Set(newSceneIndex.ToString());
+            }
         }
 
         /// <summary>
         /// Create a new scene and set it as current scene
         /// </summary>
-        public void SetNewScneneAsCurrentScene()
+        public void SetNewSceneAsCurrentScene()
         {
             SceneDirectoryState newScene = SceneDirectoryState.CreateNewSceneDirectoryState();
             sceneManagerState.AddSceneDirectoryState(newScene);
@@ -345,7 +356,7 @@ namespace Assets.Scripts.System
 
         private void CreateMenuBarItems()
         {
-            menuBarSystem.AddMenuItem("File#1/New Scene#1", SetNewScneneAsCurrentScene);
+            menuBarSystem.AddMenuItem("File#1/New Scene#1", SetNewSceneAsCurrentScene);
             menuBarSystem.AddMenuItem("File#1/Open Scene#2", SetDialogAsCurrentScene);
             menuBarSystem.AddMenuItem("File#1/Save Scene#3", SaveCurrentScene);
             menuBarSystem.AddMenuItem("File#1/Save Scene As...#4", SaveCurrentSceneAs);

--- a/Assets/Scripts/System/SettingsSystem.cs
+++ b/Assets/Scripts/System/SettingsSystem.cs
@@ -261,8 +261,8 @@ namespace Assets.Scripts.System
             applicationTargetFramerate = new IntClampedUserSetting(this, "Maximum frame rate", 120, 5, 1000);
             userSettings.Add(applicationTargetFramerate);
 
-            openLastOpenedScene = new IntUserSetting(this, "Open last opened scene on start up", 0);
-            userSettings.Add(openLastOpenedScene);
+            openLastOpenedScene = new StringUserSetting(this, "Open last opened scene on start up", "");
+            //userSettings.Add(openLastOpenedScene);
 
             ShownSettings.Add("User Settings", userSettings);
 
@@ -289,7 +289,7 @@ namespace Assets.Scripts.System
         public IntUserSetting TestInteger;
         public StringUserSetting TestString;
         public IntClampedUserSetting applicationTargetFramerate;
-        public IntUserSetting openLastOpenedScene;
+        public StringUserSetting openLastOpenedScene;
 
         public Vec3ProjectSetting TestProjVec3;
         public StringProjectSetting TestProjString;

--- a/Assets/Scripts/System/SettingsSystem.cs
+++ b/Assets/Scripts/System/SettingsSystem.cs
@@ -261,6 +261,9 @@ namespace Assets.Scripts.System
             applicationTargetFramerate = new IntClampedUserSetting(this, "Maximum frame rate", 120, 5, 1000);
             userSettings.Add(applicationTargetFramerate);
 
+            openLastOpenedScene = new IntUserSetting(this, "Open last opened scene on start up", 0);
+            userSettings.Add(openLastOpenedScene);
+
             ShownSettings.Add("User Settings", userSettings);
 
 
@@ -286,6 +289,7 @@ namespace Assets.Scripts.System
         public IntUserSetting TestInteger;
         public StringUserSetting TestString;
         public IntClampedUserSetting applicationTargetFramerate;
+        public IntUserSetting openLastOpenedScene;
 
         public Vec3ProjectSetting TestProjVec3;
         public StringProjectSetting TestProjString;

--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -42,10 +42,7 @@ namespace Assets.Scripts.System
 
             sceneManagerSystem.DiscoverScenes();
 
-            // TODO: load proper scene. Work around is to load the first scene
-            //sceneManagerSystem.SetFirstSceneAsCurrentScene();
-
-            sceneManagerSystem.SetLastOpenedSceneAsCurrentScene(settingsSystem.openLastOpenedScene);
+            sceneManagerSystem.SetLastOpenedSceneAsCurrentScene();
         }
 
         void Start()

--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -43,9 +43,9 @@ namespace Assets.Scripts.System
             sceneManagerSystem.DiscoverScenes();
 
             // TODO: load proper scene. Work around is to load the first scene
-            sceneManagerSystem.SetFirstSceneAsCurrentScene();
+            //sceneManagerSystem.SetFirstSceneAsCurrentScene();
 
-            sceneManagerSystem.SetLastOpenedSceneAsCurrentScene(settingsSystem.openLastOpenedScene.Get());
+            sceneManagerSystem.SetLastOpenedSceneAsCurrentScene(settingsSystem.openLastOpenedScene);
         }
 
         void Start()

--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -16,6 +16,7 @@ namespace Assets.Scripts.System
         private FrameTimeSystem frameTimeSystem;
         private SceneManagerSystem sceneManagerSystem;
         private SceneViewSystem sceneViewSystem;
+        private SettingsSystem settingsSystem;
 
         [Inject]
         private void Construct(
@@ -24,13 +25,15 @@ namespace Assets.Scripts.System
             IPathState pathState,
             FrameTimeSystem frameTimeSystem,
             SceneManagerSystem sceneManagerSystem,
-            SceneViewSystem sceneViewSystem)
+            SceneViewSystem sceneViewSystem,
+            SettingsSystem settingsSystem)
         {
             this.assetManagerSystem = assetManagerSystem;
             this.workspaceSaveSystem = workspaceSaveSystem;
             this.frameTimeSystem = frameTimeSystem;
             this.sceneManagerSystem = sceneManagerSystem;
             this.sceneViewSystem = sceneViewSystem;
+            this.settingsSystem = settingsSystem;
         }
 
         void Awake()
@@ -41,6 +44,8 @@ namespace Assets.Scripts.System
 
             // TODO: load proper scene. Work around is to load the first scene
             sceneManagerSystem.SetFirstSceneAsCurrentScene();
+
+            sceneManagerSystem.SetLastOpenedSceneAsCurrentScene(settingsSystem.openLastOpenedScene.Get());
         }
 
         void Start()

--- a/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
+++ b/Assets/Scripts/Tests/EditModeTests/LoadSaveSceneV2Test.cs
@@ -76,6 +76,9 @@ namespace Assets.Scripts.Tests.EditModeTests
             SceneManagerSystem sceneManagerSystem = new SceneManagerSystem();
             EditorEvents editorEvents = new EditorEvents();
             MenuBarState menuBarState = new MenuBarState();
+            ProjectSettingState projectSettingState = new ProjectSettingState();
+            SettingsSystem settingsSystem = new SettingsSystem(projectSettingState, sceneSettingState, editorEvents);
+
 
             menuBarSystem.Construct(editorEvents, menuBarState);
             sceneSettingState.Construct(pathState, sceneManagerState);
@@ -89,7 +92,8 @@ namespace Assets.Scripts.Tests.EditModeTests
                 workspaceSaveSystem,
                 typeScriptGenerationSystem,
                 sceneViewSystem,
-                menuBarSystem);
+                menuBarSystem,
+                settingsSystem);
 
             var scenePath = pathState.ProjectPath + "/dcl-edit/saves/v2/New Scene.dclscene";
 


### PR DESCRIPTION
This task is in draft as left to check or save the current scene index and load it when option enable on settings, also would be nice to change option text field to checkbox.