### PR TITLE
Ref/feature/hierarchy order

### DIFF
--- a/Assets/Design/ColorPresets/DarkgrayGray.asset
+++ b/Assets/Design/ColorPresets/DarkgrayGray.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54d21f6ece3b46479f0c328f8c6007e0, type: 3}
+  m_Name: DarkgrayGray
+  m_EditorClassIdentifier: 
+  colorMode: 2
+  topLeft: {r: 0.5283019, g: 0.5283019, b: 0.5283019, a: 1}
+  topRight: {r: 0.5283019, g: 0.5283019, b: 0.5283019, a: 1}
+  bottomLeft: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}
+  bottomRight: {r: 0.2735849, g: 0.2735849, b: 0.2735849, a: 1}

--- a/Assets/Design/ColorPresets/DarkgrayGray.asset.meta
+++ b/Assets/Design/ColorPresets/DarkgrayGray.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 479fa25d43f3a734e815874f8171d407
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UIDesign/Atoms/HierarchyItem.prefab
+++ b/Assets/Prefabs/UIDesign/Atoms/HierarchyItem.prefab
@@ -1,5 +1,80 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2356130675631690032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 767383567318895750}
+  - component: {fileID: 6721166743734292226}
+  - component: {fileID: 3798629909193452586}
+  m_Layer: 5
+  m_Name: Hover Image First Child As Lower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &767383567318895750
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2356130675631690032}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7422797023849748747}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: -2}
+  m_SizeDelta: {x: 0, y: 4}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &6721166743734292226
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2356130675631690032}
+  m_CullTransparentMesh: 1
+--- !u!114 &3798629909193452586
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2356130675631690032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.34509805, b: 0.5921569, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &2422755671683187676
 GameObject:
   m_ObjectHideFlags: 0
@@ -29,13 +104,105 @@ RectTransform:
   m_Children:
   - {fileID: 3812687420822348181}
   m_Father: {fileID: 2265490378801644114}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 30, y: 0}
   m_Pivot: {x: 0, y: 0.5}
+--- !u!1 &2486696028154154901
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7660201348995256231}
+  - component: {fileID: 3226367638321152559}
+  - component: {fileID: 8837827098160743855}
+  - component: {fileID: 6488294087716392908}
+  m_Layer: 5
+  m_Name: Upper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7660201348995256231
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2486696028154154901}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5362252017976071021}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.75}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.50006104, y: 0}
+  m_SizeDelta: {x: 1.0001221, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3226367638321152559
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2486696028154154901}
+  m_CullTransparentMesh: 1
+--- !u!114 &8837827098160743855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2486696028154154901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &6488294087716392908
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2486696028154154901}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd1af13020f046e2affc4a6908972dac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clickableImage: {fileID: 8837827098160743855}
+  hoverImageDefault: {fileID: 8095590498270583388}
+  hoverImageSpecial: {fileID: 8723935553923540729}
+  rayCastTarget: 0
 --- !u!1 &2570515792709860737
 GameObject:
   m_ObjectHideFlags: 0
@@ -47,6 +214,7 @@ GameObject:
   - component: {fileID: 4572500443968408437}
   - component: {fileID: 7021667795846845239}
   - component: {fileID: -3399197616908110466}
+  - component: {fileID: 645970969838876487}
   m_Layer: 5
   m_Name: HierarchyItem
   m_TagString: Untagged
@@ -90,7 +258,8 @@ MonoBehaviour:
   arrow: {fileID: 4611500091154730652}
   arrowContainer: {fileID: 3812687420822348181}
   indent: {fileID: 2265490378801644114}
-  rightClickHandler: {fileID: 3541963152108461758}
+  rightClickHandler: {fileID: 4001524395178144772}
+  dragAndDropHandler: {fileID: 645970969838876487}
 --- !u!114 &-3399197616908110466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -111,6 +280,26 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!114 &645970969838876487
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2570515792709860737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 202167157a2b4386a8b5c42a03c40148, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clickableText: {fileID: 7422797023849748744}
+  clickableTextHandler: {fileID: 1838785119936099034}
+  dropHandlerUpper: {fileID: 6488294087716392908}
+  dropHandlerCenter: {fileID: 8804126883313200850}
+  dropHandlerLower: {fileID: 7149916086415355286}
+  rightClickHandler: {fileID: 4001524395178144772}
+  isExpanded: 0
+  isParentExpanded: 0
 --- !u!1 &3805850520352286205
 GameObject:
   m_ObjectHideFlags: 0
@@ -138,6 +327,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 5277388984206885800}
   - {fileID: 7422797023849748747}
   - {fileID: 6693895610530761729}
   m_Father: {fileID: 4572500443968408437}
@@ -148,6 +338,352 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -0.000034332275, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &4237970801682263474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1750293374463621018}
+  - component: {fileID: 5595869284129399629}
+  - component: {fileID: 8095590498270583388}
+  m_Layer: 5
+  m_Name: Hover Image Upper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1750293374463621018
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4237970801682263474}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7422797023849748747}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -2}
+  m_SizeDelta: {x: 0, y: 4}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &5595869284129399629
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4237970801682263474}
+  m_CullTransparentMesh: 1
+--- !u!114 &8095590498270583388
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4237970801682263474}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.22745098, g: 0.50980395, b: 0.9372549, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4495266415186364753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5362252017976071021}
+  m_Layer: 5
+  m_Name: Drop Zones
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5362252017976071021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4495266415186364753}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 7660201348995256231}
+  - {fileID: 3197627915965472714}
+  - {fileID: 3992033509337827923}
+  m_Father: {fileID: 5277388984206885800}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &5277388984206885801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5277388984206885800}
+  - component: {fileID: 5277388984206885802}
+  - component: {fileID: 5875216420371306695}
+  m_Layer: 5
+  m_Name: Drag and Drop
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5277388984206885800
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5277388984206885801}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 5362252017976071021}
+  m_Father: {fileID: 2265490378801644114}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &5277388984206885802
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5277388984206885801}
+  m_CullTransparentMesh: 1
+--- !u!114 &5875216420371306695
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5277388984206885801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 50
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &5317848995077184233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4191774626051795555}
+  - component: {fileID: 1398527929554827304}
+  - component: {fileID: 6521808637700875367}
+  m_Layer: 5
+  m_Name: Hover Image Last Child
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4191774626051795555
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5317848995077184233}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7422797023849748747}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &1398527929554827304
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5317848995077184233}
+  m_CullTransparentMesh: 1
+--- !u!114 &6521808637700875367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5317848995077184233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.3443396, b: 0.5910933, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &5509034554453684258
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3992033509337827923}
+  - component: {fileID: 1962497354130477783}
+  - component: {fileID: 2456801160812073633}
+  - component: {fileID: 7149916086415355286}
+  m_Layer: 5
+  m_Name: Lower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3992033509337827923
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5509034554453684258}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5362252017976071021}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0.25}
+  m_AnchoredPosition: {x: -0.49993896, y: 0}
+  m_SizeDelta: {x: -0.9998779, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1962497354130477783
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5509034554453684258}
+  m_CullTransparentMesh: 1
+--- !u!114 &2456801160812073633
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5509034554453684258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &7149916086415355286
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5509034554453684258}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd1af13020f046e2affc4a6908972dac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clickableImage: {fileID: 2456801160812073633}
+  hoverImageDefault: {fileID: 2606418290549324382}
+  hoverImageSpecial: {fileID: 3798629909193452586}
+  rayCastTarget: 0
 --- !u!1 &5821854488045921361
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,6 +864,248 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!1 &6977139223119915680
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3197627915965472714}
+  - component: {fileID: 2948424791782052845}
+  - component: {fileID: 2872405968681831932}
+  - component: {fileID: 8804126883313200850}
+  m_Layer: 5
+  m_Name: Center
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3197627915965472714
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6977139223119915680}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5362252017976071021}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0.000061035156, y: 0}
+  m_SizeDelta: {x: 0.00012207031, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2948424791782052845
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6977139223119915680}
+  m_CullTransparentMesh: 1
+--- !u!114 &2872405968681831932
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6977139223119915680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8804126883313200850
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6977139223119915680}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd1af13020f046e2affc4a6908972dac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clickableImage: {fileID: 2872405968681831932}
+  hoverImageDefault: {fileID: 6521808637700875367}
+  hoverImageSpecial: {fileID: 6521808637700875367}
+  rayCastTarget: 0
+--- !u!1 &8101001665118133855
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 618648558506838257}
+  - component: {fileID: 482875301994391080}
+  - component: {fileID: 8723935553923540729}
+  m_Layer: 5
+  m_Name: Hover Image First Child As Upper
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &618648558506838257
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8101001665118133855}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7422797023849748747}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -10, y: -2}
+  m_SizeDelta: {x: 20, y: 4}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &482875301994391080
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8101001665118133855}
+  m_CullTransparentMesh: 1
+--- !u!114 &8723935553923540729
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8101001665118133855}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0.34509805, b: 0.5921569, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8258921507491631512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 201467127185483708}
+  - component: {fileID: 8891874894480311423}
+  - component: {fileID: 2606418290549324382}
+  m_Layer: 5
+  m_Name: Hover Image Lower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &201467127185483708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8258921507491631512}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 7422797023849748747}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: -2}
+  m_SizeDelta: {x: 0, y: 4}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!222 &8891874894480311423
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8258921507491631512}
+  m_CullTransparentMesh: 1
+--- !u!114 &2606418290549324382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8258921507491631512}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.22745098, g: 0.50980395, b: 0.9372549, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1001 &601275020809375877
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -335,10 +1113,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2265490378801644114}
     m_Modifications:
-    - target: {fileID: 8024071907148859789, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
-      propertyPath: m_enableWordWrapping
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 8024071907148859789, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
       propertyPath: m_HorizontalAlignment
       value: 1
@@ -357,7 +1131,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8024071907148859790, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
       propertyPath: m_RootOrder
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8024071907148859790, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
       propertyPath: m_AnchorMax.x
@@ -433,31 +1207,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8024071907148859791, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
       propertyPath: m_Name
-      value: Text
+      value: Draggable Text
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
---- !u!1 &7422797023849748746 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 8024071907148859791, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
-  m_PrefabInstance: {fileID: 601275020809375877}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &7422797023849748747 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8024071907148859790, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
-  m_PrefabInstance: {fileID: 601275020809375877}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &7422797023849748744 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8024071907148859789, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
-  m_PrefabInstance: {fileID: 601275020809375877}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7422797023849748746}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1838785119936099034 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1287049970833695327, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
@@ -469,19 +1222,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 169b2e350ae095b41939620222df4067, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &3541963152108461758
+--- !u!114 &7422797023849748744 stripped
 MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 8024071907148859789, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
+  m_PrefabInstance: {fileID: 601275020809375877}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7422797023849748746}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f0ae3498c713ae4cbdcca21dc117379, type: 3}
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5347190927912761868
+--- !u!224 &7422797023849748747 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8024071907148859790, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
+  m_PrefabInstance: {fileID: 601275020809375877}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7422797023849748746 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8024071907148859791, guid: 940a8e80e3325354b9baed45c93a96f0, type: 3}
+  m_PrefabInstance: {fileID: 601275020809375877}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1720677584444286684
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -525,3 +1287,15 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4001524395178144772
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7422797023849748746}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f0ae3498c713ae4cbdcca21dc117379, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/UIDesign/Atoms/Spacer.prefab
+++ b/Assets/Prefabs/UIDesign/Atoms/Spacer.prefab
@@ -15,6 +15,7 @@ GameObject:
   - component: {fileID: 3792036319085715899}
   - component: {fileID: 4796978486173793332}
   - component: {fileID: 2093113546583741110}
+  - component: {fileID: 971809147286760089}
   m_Layer: 0
   m_Name: Spacer
   m_TagString: Untagged
@@ -32,7 +33,8 @@ RectTransform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 2122490060808443073}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -74,6 +76,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rightClickHandler: {fileID: 4796978486173793332}
+  dropHandler: {fileID: 971809147286760089}
 --- !u!222 &8951285334110812333
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -95,7 +98,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -137,3 +140,94 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+--- !u!114 &971809147286760089
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 889315105189934788}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd1af13020f046e2affc4a6908972dac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  clickableImage: {fileID: 3792036319085715899}
+  hoverImageDefault: {fileID: 513654065776394079}
+  hoverImageOnTop: {fileID: 513654065776394079}
+  rayCastTarget: 0
+--- !u!1 &6912314521369820767
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2122490060808443073}
+  - component: {fileID: 3844653060683355172}
+  - component: {fileID: 513654065776394079}
+  m_Layer: 5
+  m_Name: Hover Image Lower
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2122490060808443073
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6912314521369820767}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6451589943504269030}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 15, y: 0}
+  m_SizeDelta: {x: -30, y: 4}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &3844653060683355172
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6912314521369820767}
+  m_CullTransparentMesh: 1
+--- !u!114 &513654065776394079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6912314521369820767}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.22745098, g: 0.50980395, b: 0.9372549, a: 0}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 0
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Prefabs/UIDesign/Atoms/Text.prefab
+++ b/Assets/Prefabs/UIDesign/Atoms/Text.prefab
@@ -151,6 +151,7 @@ MonoBehaviour:
   NormalColorGradient: {fileID: 11400000, guid: c2e3fb0467bc7af4b9ced519e3efe75d, type: 2}
   PrimaryColorGradient: {fileID: 11400000, guid: fd55bb3cc1e5ba944b4bb9f9aa355a18, type: 2}
   SecondaryColorGradient: {fileID: 11400000, guid: 391ea3c2d39da864c959c30ce56a8da1, type: 2}
+  DisabledColorGradient: {fileID: 11400000, guid: 479fa25d43f3a734e815874f8171d407, type: 2}
   TextComponent: {fileID: 8024071907148859789}
 --- !u!114 &8642057508157690593
 MonoBehaviour:

--- a/Assets/Scripts/Command/AddEntity.cs
+++ b/Assets/Scripts/Command/AddEntity.cs
@@ -18,8 +18,11 @@ namespace Assets.Scripts.Command
         private readonly Guid id;
 
         private readonly SelectionUtility.SelectionWrapper oldSelection;
+        
+        private readonly float? hierarchyOrder;
 
-        public AddEntity(Guid oldPrimarySelection, IEnumerable<Guid> oldSecondarySelection, EntityPresetState.EntityPreset preset, Guid parent = default)
+        public AddEntity(Guid oldPrimarySelection, IEnumerable<Guid> oldSecondarySelection,
+            EntityPresetState.EntityPreset preset, float? hierarchyOrder, Guid parent = default)
         {
             this.preset = preset;
             this.parent = parent;
@@ -29,6 +32,7 @@ namespace Assets.Scripts.Command
                 Primary = oldPrimarySelection,
                 Secondary = oldSecondarySelection.ToList()
             };
+            this.hierarchyOrder = hierarchyOrder;
         }
 
         public override string Name => "Add Entity";
@@ -36,7 +40,7 @@ namespace Assets.Scripts.Command
 
         public override void Do(DclScene sceneState, EditorEvents editorEvents)
         {
-            var entity = EntityUtility.AddEntity(sceneState, id, preset.name, parent);
+            var entity = EntityUtility.AddEntity(sceneState, id, preset.name, hierarchyOrder, parent);
 
             EntityUtility.AddDefaultTransformComponent(entity);
 

--- a/Assets/Scripts/Command/AddEntity.cs
+++ b/Assets/Scripts/Command/AddEntity.cs
@@ -19,10 +19,10 @@ namespace Assets.Scripts.Command
 
         private readonly SelectionUtility.SelectionWrapper oldSelection;
         
-        private readonly float? hierarchyOrder;
+        private readonly float hierarchyOrder;
 
         public AddEntity(Guid oldPrimarySelection, IEnumerable<Guid> oldSecondarySelection,
-            EntityPresetState.EntityPreset preset, float? hierarchyOrder, Guid parent = default)
+            EntityPresetState.EntityPreset preset, float hierarchyOrder, Guid parent = default)
         {
             this.preset = preset;
             this.parent = parent;

--- a/Assets/Scripts/Command/AddModelAssetToScene.cs
+++ b/Assets/Scripts/Command/AddModelAssetToScene.cs
@@ -15,9 +15,9 @@ namespace Assets.Scripts.Command
         string _entityCustomName;
         Guid _assetId;
         Vector3 _positionInScene;
-        private float? hierarchyOrder;
+        private float hierarchyOrder;
 
-        public AddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene, float? hierarchyOrder)
+        public AddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene, float hierarchyOrder)
         {
             _entityId = entityId;
             _entityCustomName = entityCustomName;

--- a/Assets/Scripts/Command/AddModelAssetToScene.cs
+++ b/Assets/Scripts/Command/AddModelAssetToScene.cs
@@ -15,18 +15,20 @@ namespace Assets.Scripts.Command
         string _entityCustomName;
         Guid _assetId;
         Vector3 _positionInScene;
+        private float? hierarchyOrder;
 
-        public AddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene)
+        public AddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene, float? hierarchyOrder)
         {
             _entityId = entityId;
             _entityCustomName = entityCustomName;
             _assetId = assetId;
             _positionInScene = positionInScene;
+            this.hierarchyOrder = hierarchyOrder;
         }
 
         public override void Do(DclScene sceneState, EditorEvents editorEvents)
         {
-            var newEntity = EntityUtility.AddEntity(sceneState, _entityId, _entityCustomName);
+            var newEntity = EntityUtility.AddEntity(sceneState, _entityId, _entityCustomName, hierarchyOrder, default);
 
             var transformComponent = new DclTransformComponent(_positionInScene);
             newEntity.AddComponent(transformComponent);

--- a/Assets/Scripts/Command/ChangeHierarchyOrder.cs
+++ b/Assets/Scripts/Command/ChangeHierarchyOrder.cs
@@ -11,14 +11,14 @@ namespace Assets.Scripts.Command
         private readonly Guid draggedEntityId;
         private readonly Guid hoveredEntityId;
         private readonly Guid startParentId;
-        private readonly float? startHierarchyOrder;
+        private readonly float startHierarchyOrder;
         private readonly bool? startExpansionStateParent;
         private readonly bool? startExpansionStateHoveredEntity;
         private DclEntity startPrimarySelection;
-        private readonly float? newHierarchyOrder;
+        private readonly float newHierarchyOrder;
         private readonly Guid newParentId;
 
-        public ChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity, HierarchyExpansionState hierarchyExpansionState, float? newHierarchyOrder, DclEntity newParent)
+        public ChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity, HierarchyExpansionState hierarchyExpansionState, float newHierarchyOrder, DclEntity newParent)
         {
             if (draggedEntity == null)
             {

--- a/Assets/Scripts/Command/ChangeHierarchyOrder.cs
+++ b/Assets/Scripts/Command/ChangeHierarchyOrder.cs
@@ -8,64 +8,33 @@ namespace Assets.Scripts.Command
 {
     public class ChangeHierarchyOrder : SceneState.Command
     {
-        private readonly HierarchyExpansionState hierarchyExpansionState;
-        private readonly Guid draggedEntityId;
-        private readonly Guid hoveredEntityId;
+        private readonly Guid affectedEntityId;
         private readonly Guid startParentId;
-        private readonly float startHierarchyOrder;
-        private readonly bool? startExpansionStateParent;
-        private readonly bool? startExpansionStateHoveredEntity;
-        private DclEntity startPrimarySelection;
-        private readonly float newHierarchyOrder;
         private readonly Guid newParentId;
-        private readonly bool shouldExpand;
+        private readonly float startHierarchyOrder;
+        private readonly float newHierarchyOrder;
 
-        public ChangeHierarchyOrder(DclEntity draggedEntity, [CanBeNull] DclEntity hoveredEntity, HierarchyExpansionState hierarchyExpansionState, float newHierarchyOrder, [CanBeNull] DclEntity newParent, bool shouldExpand)
+        public ChangeHierarchyOrder(Guid affectedEntityId, Guid startParentId, float startHierarchyOrder, float newHierarchyOrder, Guid newParentId)
         {
-            this.hierarchyExpansionState = hierarchyExpansionState;
-            
-            startParentId = draggedEntity.ParentId;
-            startHierarchyOrder = draggedEntity.hierarchyOrder;
-            
-            draggedEntityId = draggedEntity.Id;
-            hoveredEntityId = hoveredEntity?.Id ?? default;
-            newParentId = newParent?.Id ?? default;
+            this.startParentId = startParentId;
+            this.startHierarchyOrder = startHierarchyOrder;
+            this.affectedEntityId = affectedEntityId;
+            this.newParentId = newParentId;
             this.newHierarchyOrder = newHierarchyOrder;
-            
-            this.shouldExpand = shouldExpand;
-            
-            if (startParentId != default)
-            {
-                startExpansionStateParent = hierarchyExpansionState.IsExpanded(startParentId);
-            }
-            
-            if (hoveredEntity != null)
-            {
-                startExpansionStateHoveredEntity = hierarchyExpansionState.IsExpanded(hoveredEntity.Id);
-            }
         }
 
         public override string Name => "Change Entity Hierarchy Order";
 
         public override string Description =>
-            $"Changing hierarchy order of Entity with id: \"{draggedEntityId}\"";
+            $"Changing hierarchy order of Entity with id: \"{affectedEntityId}\"";
 
         public override void Do(DclScene sceneState, EditorEvents editorEvents)
         {
-            var hoveredEntity  = hoveredEntityId == default ? null : sceneState.GetEntityById(hoveredEntityId);
-            var draggedEntity  = sceneState.GetEntityById(draggedEntityId);
+            var draggedEntity  = sceneState.GetEntityById(affectedEntityId);
             var newParent = newParentId == default ? null : sceneState.GetEntityById(newParentId);
 
             draggedEntity.hierarchyOrder = newHierarchyOrder;
             draggedEntity.Parent = newParent;
-
-            startPrimarySelection = sceneState.SelectionState.PrimarySelectedEntity;
-            sceneState.SelectionState.PrimarySelectedEntity = draggedEntity;
-
-            if (shouldExpand && hoveredEntity != null)
-            {
-                hierarchyExpansionState.SetExpanded(hoveredEntity.Id, true);
-            }
 
             editorEvents.InvokeHierarchyChangedEvent();
             editorEvents.InvokeSelectionChangedEvent();
@@ -74,7 +43,7 @@ namespace Assets.Scripts.Command
 
         public override void Undo(DclScene sceneState, EditorEvents editorEvents)
         {
-            var draggedEntity  = draggedEntityId == default ? null : sceneState.GetEntityById(draggedEntityId);
+            var draggedEntity  = affectedEntityId == default ? null : sceneState.GetEntityById(affectedEntityId);
             var startParent = startParentId == default ? null : sceneState.GetEntityById(startParentId);
 
             if (draggedEntity == null)
@@ -84,18 +53,6 @@ namespace Assets.Scripts.Command
 
             draggedEntity.Parent = startParent;
             draggedEntity.hierarchyOrder = startHierarchyOrder;
-
-            if (startExpansionStateParent != null)
-            {
-                hierarchyExpansionState.SetExpanded(startParentId, (bool)startExpansionStateParent);
-            }
-            
-            if (hoveredEntityId != default && startExpansionStateHoveredEntity != null)
-            {
-                hierarchyExpansionState.SetExpanded(hoveredEntityId, (bool)startExpansionStateHoveredEntity);
-            }
-
-            sceneState.SelectionState.PrimarySelectedEntity = startPrimarySelection;
 
             editorEvents.InvokeHierarchyChangedEvent();
             editorEvents.InvokeSelectionChangedEvent();

--- a/Assets/Scripts/Command/ChangeHierarchyOrder.cs
+++ b/Assets/Scripts/Command/ChangeHierarchyOrder.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using Assets.Scripts.Events;
+using Assets.Scripts.SceneState;
+
+namespace Assets.Scripts.Command
+{
+    public class ChangeHierarchyOrder : SceneState.Command
+    {
+        private readonly HierarchyExpansionState hierarchyExpansionState;
+        private readonly Guid draggedEntityId;
+        private readonly Guid hoveredEntityId;
+        private readonly Guid startParentId;
+        private readonly float? startHierarchyOrder;
+        private readonly bool? startExpansionStateParent;
+        private readonly bool? startExpansionStateHoveredEntity;
+        private DclEntity startPrimarySelection;
+        private readonly float? newHierarchyOrder;
+        private readonly Guid newParentId;
+
+        public ChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity, HierarchyExpansionState hierarchyExpansionState, float? newHierarchyOrder, DclEntity newParent)
+        {
+            if (draggedEntity == null)
+            {
+                return;
+            }
+
+            startParentId = draggedEntity.Parent?.Id ?? default;
+            startHierarchyOrder = draggedEntity.hierarchyOrder;
+            
+            draggedEntityId = draggedEntity.Id;
+            hoveredEntityId = hoveredEntity?.Id ?? default;
+            this.hierarchyExpansionState = hierarchyExpansionState;
+            
+            this.newHierarchyOrder = newHierarchyOrder;
+            newParentId = newParent?.Id ?? default;
+            
+            if (startParentId != default)
+            {
+                startExpansionStateParent = hierarchyExpansionState.IsExpanded(startParentId);
+            }
+            
+            if (hoveredEntity != null)
+            {
+                startExpansionStateHoveredEntity = hierarchyExpansionState.IsExpanded(hoveredEntity.Id);
+            }
+        }
+
+        public override string Name => "Change Entity Hierarchy Order";
+
+        public override string Description =>
+            $"Changing hierarchy order of Entity with id: \"{draggedEntityId}\"";
+
+        public override void Do(DclScene sceneState, EditorEvents editorEvents)
+        {
+            var hoveredEntity  = hoveredEntityId == default ? null : sceneState.GetEntityById(hoveredEntityId);
+            var draggedEntity  = sceneState.GetEntityById(draggedEntityId);
+            var newParent = newParentId == default ? null : sceneState.GetEntityById(newParentId);
+
+            if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsSuccessorOf(draggedEntity)))
+            {
+                editorEvents.InvokeHierarchyChangedEvent();
+                return;
+            }
+            
+            draggedEntity.hierarchyOrder = newHierarchyOrder;
+            draggedEntity.Parent = newParent;
+
+            startPrimarySelection = sceneState.SelectionState.PrimarySelectedEntity;
+            sceneState.SelectionState.PrimarySelectedEntity = draggedEntity;
+            
+            if (newParent != null && hoveredEntity != null && newParentId.Equals(hoveredEntityId))
+            {
+                hierarchyExpansionState.SetExpanded(hoveredEntity.Id, true);
+            }
+
+            editorEvents.InvokeHierarchyChangedEvent();
+            editorEvents.InvokeSelectionChangedEvent();
+        }
+
+
+        public override void Undo(DclScene sceneState, EditorEvents editorEvents)
+        {
+            var draggedEntity  = draggedEntityId == default ? null : sceneState.GetEntityById(draggedEntityId);
+            var startParent = startParentId == default ? null : sceneState.GetEntityById(startParentId);
+
+            if (draggedEntity == null)
+            {
+                return;
+            }
+
+            draggedEntity.Parent = startParent;
+            draggedEntity.hierarchyOrder = startHierarchyOrder;
+
+            if (startExpansionStateParent != null)
+            {
+                hierarchyExpansionState.SetExpanded(startParentId, (bool)startExpansionStateParent);
+            }
+            
+            if (hoveredEntityId != default && startExpansionStateHoveredEntity != null)
+            {
+                hierarchyExpansionState.SetExpanded(hoveredEntityId, (bool)startExpansionStateHoveredEntity);
+            }
+
+            sceneState.SelectionState.PrimarySelectedEntity = startPrimarySelection;
+
+            editorEvents.InvokeHierarchyChangedEvent();
+            editorEvents.InvokeSelectionChangedEvent();
+        }
+
+    }
+}

--- a/Assets/Scripts/Command/ChangeHierarchyOrder.cs
+++ b/Assets/Scripts/Command/ChangeHierarchyOrder.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Linq;
 using Assets.Scripts.Events;
 using Assets.Scripts.SceneState;
-using JetBrains.Annotations;
 
 namespace Assets.Scripts.Command
 {
@@ -30,11 +28,11 @@ namespace Assets.Scripts.Command
 
         public override void Do(DclScene sceneState, EditorEvents editorEvents)
         {
-            var draggedEntity  = sceneState.GetEntityById(affectedEntityId);
+            var affectedEntity  = sceneState.GetEntityById(affectedEntityId);
             var newParent = newParentId == default ? null : sceneState.GetEntityById(newParentId);
 
-            draggedEntity.hierarchyOrder = newHierarchyOrder;
-            draggedEntity.Parent = newParent;
+            affectedEntity.hierarchyOrder = newHierarchyOrder;
+            affectedEntity.Parent = newParent;
 
             editorEvents.InvokeHierarchyChangedEvent();
             editorEvents.InvokeSelectionChangedEvent();
@@ -43,16 +41,11 @@ namespace Assets.Scripts.Command
 
         public override void Undo(DclScene sceneState, EditorEvents editorEvents)
         {
-            var draggedEntity  = affectedEntityId == default ? null : sceneState.GetEntityById(affectedEntityId);
+            var affectedEntity  = sceneState.GetEntityById(affectedEntityId);
             var startParent = startParentId == default ? null : sceneState.GetEntityById(startParentId);
 
-            if (draggedEntity == null)
-            {
-                return;
-            }
-
-            draggedEntity.Parent = startParent;
-            draggedEntity.hierarchyOrder = startHierarchyOrder;
+            affectedEntity.Parent = startParent;
+            affectedEntity.hierarchyOrder = startHierarchyOrder;
 
             editorEvents.InvokeHierarchyChangedEvent();
             editorEvents.InvokeSelectionChangedEvent();

--- a/Assets/Scripts/Command/ChangeHierarchyOrder.cs.meta
+++ b/Assets/Scripts/Command/ChangeHierarchyOrder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 13007b2399134ded9a6945cac8f101a5
+timeCreated: 1674758934

--- a/Assets/Scripts/Command/DuplicateEntity.cs
+++ b/Assets/Scripts/Command/DuplicateEntity.cs
@@ -17,10 +17,12 @@ public class DuplicateEntity : Command
     private int seed;
 
     private List<DclEntity> secondarySelectedEntities;
+    private readonly float? hierarchyOrder;
 
-    public DuplicateEntity(Guid entityId)
+    public DuplicateEntity(Guid entityId, float? hierarchyOrder)
     {
         this.entityId = entityId;
+        this.hierarchyOrder = hierarchyOrder;
         System.Random rand = new System.Random();
         this.seed = rand.Next();
     }
@@ -29,7 +31,7 @@ public class DuplicateEntity : Command
     {
         DclEntity entity = sceneState.GetEntityById(entityId);
 
-        DclEntity newEntity = entity.DeepCopy(sceneState, new System.Random(this.seed));
+        DclEntity newEntity = entity.DeepCopy(sceneState, new System.Random(this.seed), hierarchyOrder);
 
         this.doupEntityId = newEntity.Id;
 

--- a/Assets/Scripts/Command/DuplicateEntity.cs
+++ b/Assets/Scripts/Command/DuplicateEntity.cs
@@ -17,9 +17,9 @@ public class DuplicateEntity : Command
     private int seed;
 
     private List<DclEntity> secondarySelectedEntities;
-    private readonly float? hierarchyOrder;
+    private readonly float hierarchyOrder;
 
-    public DuplicateEntity(Guid entityId, float? hierarchyOrder)
+    public DuplicateEntity(Guid entityId, float hierarchyOrder)
     {
         this.entityId = entityId;
         this.hierarchyOrder = hierarchyOrder;

--- a/Assets/Scripts/Command/Utility/EntityUtility.cs
+++ b/Assets/Scripts/Command/Utility/EntityUtility.cs
@@ -15,7 +15,7 @@ namespace Assets.Scripts.Command.Utility
         /// <param name="hierarchyOrder">The hierarchy order of the entity</param>
         /// <param name="parent">The parent of the entity</param>
         /// <returns>Reference to new entity</returns>
-        public static DclEntity AddEntity(DclScene scene, Guid id, string name, float? hierarchyOrder,
+        public static DclEntity AddEntity(DclScene scene, Guid id, string name, float hierarchyOrder,
             Guid parent = default)
         {
             DclEntity entity = new DclEntity(id, name, parent, default, hierarchyOrder);

--- a/Assets/Scripts/Command/Utility/EntityUtility.cs
+++ b/Assets/Scripts/Command/Utility/EntityUtility.cs
@@ -12,11 +12,13 @@ namespace Assets.Scripts.Command.Utility
         /// <param name="scene">The scene to add the entity to</param>
         /// <param name="id">The guid of the entity</param>
         /// <param name="name">The name of the entity</param>
+        /// <param name="hierarchyOrder">The hierarchy order of the entity</param>
         /// <param name="parent">The parent of the entity</param>
         /// <returns>Reference to new entity</returns>
-        public static DclEntity AddEntity(DclScene scene, Guid id, string name, Guid parent = default)
+        public static DclEntity AddEntity(DclScene scene, Guid id, string name, float? hierarchyOrder,
+            Guid parent = default)
         {
-            DclEntity entity = new DclEntity(id, name, parent);
+            DclEntity entity = new DclEntity(id, name, parent, default, hierarchyOrder);
             scene.AddEntity(entity);
             
             return entity;

--- a/Assets/Scripts/Installers/DclEditorInstaller.cs
+++ b/Assets/Scripts/Installers/DclEditorInstaller.cs
@@ -165,5 +165,7 @@ public class DclEditorInstaller : MonoInstaller
         Container.BindInterfacesAndSelfTo<DialogSystem>().AsSingle();
 
         Container.BindInterfacesAndSelfTo<DialogState>().AsSingle();
+
+        Container.BindInterfacesAndSelfTo<HierarchyOrderSystem>().AsSingle();
     }
 }

--- a/Assets/Scripts/Installers/DclEditorInstaller.cs
+++ b/Assets/Scripts/Installers/DclEditorInstaller.cs
@@ -167,5 +167,7 @@ public class DclEditorInstaller : MonoInstaller
         Container.BindInterfacesAndSelfTo<DialogState>().AsSingle();
 
         Container.BindInterfacesAndSelfTo<HierarchyOrderSystem>().AsSingle();
+
+        Container.BindInterfacesAndSelfTo<AddEntitySystem>().AsSingle();
     }
 }

--- a/Assets/Scripts/Interaction/AssetButtonInteraction.cs
+++ b/Assets/Scripts/Interaction/AssetButtonInteraction.cs
@@ -62,7 +62,7 @@ public class AssetButtonInteraction : MonoBehaviour, IBeginDragHandler, IDragHan
     {
         if (!enableDragAndDrop) return;
 
-        var currentScene = sceneManagerSystem.GetCurrentScene();
+        var currentScene = sceneManagerSystem.GetCurrentSceneOrNull();
 
         if (currentScene == null)
         {
@@ -116,7 +116,7 @@ public class AssetButtonInteraction : MonoBehaviour, IBeginDragHandler, IDragHan
 
     private void AddEntityToScene(Vector3 position)
     {
-        sceneManagerSystem.GetCurrentScene()?.RemoveFloatingEntity(newEntity.Id);
+        sceneManagerSystem.GetCurrentSceneOrNull()?.RemoveFloatingEntity(newEntity.Id);
         switch (assetMetadata.assetType)
         {
             case AssetMetadata.AssetType.Model:

--- a/Assets/Scripts/Interaction/AssetButtonInteraction.cs
+++ b/Assets/Scripts/Interaction/AssetButtonInteraction.cs
@@ -16,25 +16,25 @@ public class AssetButtonInteraction : MonoBehaviour, IBeginDragHandler, IDragHan
     private Vector3 mousePositionInScene;
 
     // Dependencies
-    private CommandSystem commandSystem;
     private EditorEvents editorEvents;
     private InputHelper inputHelperSystem;
     private SceneManagerSystem sceneManagerSystem;
     private CameraState cameraState;
+    private AddEntitySystem addEntitySystem;
 
     [Inject]
     private void Construct(
-        CommandSystem commandSystem,
         EditorEvents editorEvents,
         InputHelper inputHelperSystem,
         SceneManagerSystem sceneManagerSystem,
-        CameraState cameraState)
+        CameraState cameraState,
+        AddEntitySystem addEntitySystem)
     {
-        this.commandSystem = commandSystem;
         this.inputHelperSystem = inputHelperSystem;
         this.sceneManagerSystem = sceneManagerSystem;
         this.editorEvents = editorEvents;
         this.cameraState = cameraState;
+        this.addEntitySystem = addEntitySystem;
     }
 
     public void OnClick()
@@ -120,8 +120,8 @@ public class AssetButtonInteraction : MonoBehaviour, IBeginDragHandler, IDragHan
         switch (assetMetadata.assetType)
         {
             case AssetMetadata.AssetType.Model:
-                commandSystem.ExecuteCommand(commandSystem.CommandFactory.CreateAddModelAssetToScene(newEntity.Id,
-                    newEntity.CustomName, assetMetadata.assetId, position));
+                addEntitySystem.AddModelAssetEntityAsCommand(newEntity, assetMetadata, position);
+
                 break;
             case AssetMetadata.AssetType.Image:
                 break;

--- a/Assets/Scripts/Interaction/GeneralInputInteraction.cs
+++ b/Assets/Scripts/Interaction/GeneralInputInteraction.cs
@@ -214,7 +214,7 @@ namespace Assets.Scripts.Interaction
             // When pressing Duplicates selected entity
             if (inputSystemAsset.Hotkeys.Duplicate.triggered)
             {
-                var currentScene = sceneManagerSystem.GetCurrentScene();
+                var currentScene = sceneManagerSystem.GetCurrentSceneOrNull();
                 var selectedEntity = currentScene?.SelectionState.PrimarySelectedEntity;
 
                 if (selectedEntity != null)
@@ -227,7 +227,7 @@ namespace Assets.Scripts.Interaction
             //When pressing Delete delete primary selected Entity
             if (inputSystemAsset.Hotkeys.Delete.triggered)
             {
-                var currentScene = sceneManagerSystem.GetCurrentScene();
+                var currentScene = sceneManagerSystem.GetCurrentSceneOrNull();
                 var selectedEntity = currentScene?.SelectionState.PrimarySelectedEntity;
                     
                 if (selectedEntity != null)
@@ -251,7 +251,7 @@ namespace Assets.Scripts.Interaction
                             if (gizmoDir == null) break;
                             Vector3 localGizmoDir = gizmoDir.GetVector();
 
-                            var entity = sceneManagerSystem.GetCurrentScene()?.SelectionState.PrimarySelectedEntity.GetTransformComponent();
+                            var entity = sceneManagerSystem.GetCurrentSceneOrNull()?.SelectionState.PrimarySelectedEntity.GetTransformComponent();
 
                             GizmoState.Mode gizmoMode = gizmoState.CurrentMode;
 
@@ -426,10 +426,10 @@ namespace Assets.Scripts.Interaction
             }
 
             // When pressing the focus hotkey and having a selected primary entity, switch to Focus Transition state
-            if (inputSystemAsset.CameraMovement.Focus.triggered && sceneManagerSystem.GetCurrentScene()?.SelectionState.PrimarySelectedEntity != null)
+            if (inputSystemAsset.CameraMovement.Focus.triggered && sceneManagerSystem.GetCurrentSceneOrNull()?.SelectionState.PrimarySelectedEntity != null)
             {
                 // Fetch position of selected object
-                var selectedEntity = sceneManagerSystem.GetCurrentScene()?.SelectionState.PrimarySelectedEntity;
+                var selectedEntity = sceneManagerSystem.GetCurrentSceneOrNull()?.SelectionState.PrimarySelectedEntity;
                 var entityPos = selectedEntity.GetTransformComponent().GlobalPosition;
 
                 // Calculate an offset position so that the camera keeps its rotation and looks at the selected entity
@@ -563,7 +563,7 @@ namespace Assets.Scripts.Interaction
         private void UpdateHoldingGizmoTool()
         {
             GizmoState.Mode mode = gizmoState.CurrentMode;
-            DclEntity selectedEntity = sceneManagerSystem.GetCurrentScene()?.SelectionState.PrimarySelectedEntity;
+            DclEntity selectedEntity = sceneManagerSystem.GetCurrentSceneOrNull()?.SelectionState.PrimarySelectedEntity;
 
             if (selectedEntity == null)
             {

--- a/Assets/Scripts/Interaction/GeneralInputInteraction.cs
+++ b/Assets/Scripts/Interaction/GeneralInputInteraction.cs
@@ -219,8 +219,6 @@ namespace Assets.Scripts.Interaction
 
                 if (selectedEntity != null)
                 {
-                    var selectedEntity = currentScene.SelectionState.PrimarySelectedEntity;
-                    
                     addEntitySystem.DuplicateEntityAsCommand(selectedEntity);
                 }
             }

--- a/Assets/Scripts/Interaction/GeneralInputInteraction.cs
+++ b/Assets/Scripts/Interaction/GeneralInputInteraction.cs
@@ -28,6 +28,7 @@ namespace Assets.Scripts.Interaction
         private ContextMenuSystem contextMenuSystem;
         private SceneManagerSystem sceneManagerSystem;
         private DialogSystem dialogSystem;
+        private AddEntitySystem addEntitySystem;
 
         [Inject]
         private void Construct(
@@ -43,7 +44,8 @@ namespace Assets.Scripts.Interaction
             EntitySelectSystem entitySelectSystem,
             ContextMenuSystem contextMenuSystem,
             SceneManagerSystem sceneManagerSystem,
-            DialogSystem dialogSystem)
+            DialogSystem dialogSystem,
+            AddEntitySystem addEntitySystem)
         {
             this.sceneSaveSystem = sceneSaveSystem;
             this.commandSystem = commandSystem;
@@ -58,6 +60,7 @@ namespace Assets.Scripts.Interaction
             this.contextMenuSystem = contextMenuSystem;
             this.sceneManagerSystem = sceneManagerSystem;
             this.dialogSystem = dialogSystem;
+            this.addEntitySystem = addEntitySystem;
         }
 
 
@@ -216,7 +219,9 @@ namespace Assets.Scripts.Interaction
 
                 if (selectedEntity != null)
                 {
-                    commandSystem.ExecuteCommand(commandSystem.CommandFactory.CreateDuplicateEntity(selectedEntity.Id));
+                    var selectedEntity = currentScene.SelectionState.PrimarySelectedEntity;
+                    
+                    addEntitySystem.DuplicateEntityAsCommand(selectedEntity);
                 }
             }
 

--- a/Assets/Scripts/SceneState/DclEntity.cs
+++ b/Assets/Scripts/SceneState/DclEntity.cs
@@ -1,11 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using Assets.Scripts.Utility;
 using JetBrains.Annotations;
 using UnityEngine;
-using static UnityEngine.EventSystems.EventTrigger;
+using Random = System.Random;
 
 
 namespace Assets.Scripts.SceneState
@@ -46,8 +45,7 @@ namespace Assets.Scripts.SceneState
             }
         }
 
-        [SerializeField]
-        private string _customName = "";
+        [SerializeField] private string _customName = "";
 
         /// <summary>
         /// The name, that is used as default 
@@ -58,6 +56,8 @@ namespace Assets.Scripts.SceneState
         public bool IsExposed { get; set; }
 
         public Guid Id { get; set; }
+
+        public float? hierarchyOrder;
 
         [CanBeNull]
         public DclEntity Parent
@@ -98,21 +98,25 @@ namespace Assets.Scripts.SceneState
         public void RemoveComponent(DclComponent component)
         {
             component.Entity = null;
-            if(!Components.Remove(component))
+            if (!Components.Remove(component))
                 Debug.Log("No Component on Entity");
         }
 
         public DclComponent GetComponentByName(string name)
         {
-            return Components.Exists(c => c.NameInCode == name) ? // if component exists
-                Components.Find(c => c.NameInCode == name) : // then return component
+            return Components.Exists(c => c.NameInCode == name)
+                ? // if component exists
+                Components.Find(c => c.NameInCode == name)
+                : // then return component
                 null; // else return null
         }
 
         public DclComponent GetComponentBySlot(string slot)
         {
-            return Components.Exists(c => c.NameOfSlot == slot) ? // if component exists
-                Components.Find(c => c.NameOfSlot == slot) : // then return component
+            return Components.Exists(c => c.NameOfSlot == slot)
+                ? // if component exists
+                Components.Find(c => c.NameOfSlot == slot)
+                : // then return component
                 null; // else return null
         }
 
@@ -147,13 +151,16 @@ namespace Assets.Scripts.SceneState
             return Components.Exists(c => c.NameOfSlot == nameOfSlot);
         }
 
-        public DclEntity(Guid id, string name = "", Guid parentId = default, bool isExposed = false)
+        public DclEntity(Guid id, string name = "", Guid parentId = default, bool isExposed = false,
+            float? hierarchyOrder = null)
         {
             Id = id;
             _customName = name;
             _parentId = parentId;
             IsExposed = isExposed;
+            this.hierarchyOrder = hierarchyOrder;
         }
+
         public Guid GenerateSeededGuid(System.Random seed)
         {
             //var r = new System.Random(seed);
@@ -164,9 +171,13 @@ namespace Assets.Scripts.SceneState
         }
 
         private System.Random _random;
-        public DclEntity DeepCopy(DclScene sceneState, System.Random random)
+
+        public DclEntity DeepCopy(DclScene sceneState, Random random, float? copyParentHierarchyOrder)
         {
-            DclEntity deepcopyEntity = new DclEntity(Id, CustomName, _parentId, false); // copied entity should never be exposed
+            var newHierarchyOrder = copyParentHierarchyOrder ?? hierarchyOrder;
+            
+            DclEntity deepcopyEntity =
+                new DclEntity(Id, CustomName, _parentId, false, newHierarchyOrder); // copied entity should never be exposed
 
             if (random != null)
             {
@@ -183,18 +194,36 @@ namespace Assets.Scripts.SceneState
                 newComponent.Entity = deepcopyEntity;
                 deepcopyEntity.AddComponent(newComponent);
             }
-            
+
             sceneState.AddEntity(deepcopyEntity);
-            
+
             if (Children.ToList().Count > 0)
             {
                 foreach (var child in Children.ToList())
                 {
-                    DclEntity newChild = child.DeepCopy(sceneState, random);
+                    DclEntity newChild = child.DeepCopy(sceneState, random, null);
                     newChild.Parent = deepcopyEntity;
                 }
             }
+
             return deepcopyEntity;
+        }
+
+        public bool IsSuccessorOf(DclEntity potentialAncestor)
+        {
+            var parent = Parent;
+        
+            while (parent != null)
+            {
+                if (parent == potentialAncestor)
+                {
+                    return true;
+                }
+                
+                parent = parent.Parent;
+            }
+
+            return false;
         }
     }
 }

--- a/Assets/Scripts/SceneState/DclEntity.cs
+++ b/Assets/Scripts/SceneState/DclEntity.cs
@@ -57,7 +57,7 @@ namespace Assets.Scripts.SceneState
 
         public Guid Id { get; set; }
 
-        public float? hierarchyOrder;
+        public float hierarchyOrder;
 
         [CanBeNull]
         public DclEntity Parent
@@ -152,7 +152,7 @@ namespace Assets.Scripts.SceneState
         }
 
         public DclEntity(Guid id, string name = "", Guid parentId = default, bool isExposed = false,
-            float? hierarchyOrder = null)
+            float hierarchyOrder = default)
         {
             Id = id;
             _customName = name;

--- a/Assets/Scripts/SceneState/DclEntity.cs
+++ b/Assets/Scripts/SceneState/DclEntity.cs
@@ -209,7 +209,7 @@ namespace Assets.Scripts.SceneState
             return deepcopyEntity;
         }
 
-        public bool IsSuccessorOf(DclEntity potentialAncestor)
+        public bool IsDescendantOf(DclEntity potentialAncestor)
         {
             var parent = Parent;
         

--- a/Assets/Scripts/SceneState/DclScene.cs
+++ b/Assets/Scripts/SceneState/DclScene.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace Assets.Scripts.SceneState
 {
@@ -40,6 +41,12 @@ namespace Assets.Scripts.SceneState
 
         public void AddEntity(DclEntity entity)
         {
+            if (entity.hierarchyOrder == null)
+            {
+                Debug.LogError("Entity needs a hierarchy order at this point!");
+                return;
+            }
+            
             entity.Scene = this;
             _allEntities.Add(entity.Id, entity);
         }

--- a/Assets/Scripts/SceneState/DclScene.cs
+++ b/Assets/Scripts/SceneState/DclScene.cs
@@ -41,12 +41,6 @@ namespace Assets.Scripts.SceneState
 
         public void AddEntity(DclEntity entity)
         {
-            if (entity.hierarchyOrder == null)
-            {
-                Debug.LogError("Entity needs a hierarchy order at this point!");
-                return;
-            }
-            
             entity.Scene = this;
             _allEntities.Add(entity.Id, entity);
         }

--- a/Assets/Scripts/System/AddEntitySystem.cs
+++ b/Assets/Scripts/System/AddEntitySystem.cs
@@ -51,8 +51,19 @@ namespace Assets.Scripts.System
 
         public void DuplicateEntityAsCommand(DclEntity selectedEntity)
         {
-            var hierarchyOrder = hierarchyOrderSystem.GetDefaultHierarchyOrder(selectedEntity.ParentId);
+            float hierarchyOrder;
+
+            var belowEntity = hierarchyOrderSystem.GetBelowSibling(selectedEntity);
             
+            if (belowEntity == null)
+            {
+                hierarchyOrder = hierarchyOrderSystem.GetHierarchyOrderPlaceBeneathSibling(selectedEntity);
+            }
+            else
+            {
+                hierarchyOrder = hierarchyOrderSystem.GetHierarchyOrderPlaceBetweenSiblings(selectedEntity, belowEntity);
+            }
+
             commandSystem.ExecuteCommand(commandSystem.CommandFactory.CreateDuplicateEntity(selectedEntity.Id, hierarchyOrder));
         }
     }

--- a/Assets/Scripts/System/AddEntitySystem.cs
+++ b/Assets/Scripts/System/AddEntitySystem.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Assets.Scripts.Command.Utility;
+using Assets.Scripts.EditorState;
+using Assets.Scripts.SceneState;
+using Assets.Scripts.Utility;
+using UnityEditor;
+using UnityEngine;
+using Zenject;
+
+namespace Assets.Scripts.System
+{
+    public class AddEntitySystem
+    {
+        // Dependencies
+        private CommandSystem commandSystem;
+        private SceneManagerSystem sceneManagerSystem;
+        private HierarchyOrderSystem hierarchyOrderSystem;
+
+        [Inject]
+        private void Construct(CommandSystem commandSystem, SceneManagerSystem sceneManagerSystem, HierarchyOrderSystem hierarchyOrderSystem)
+        {
+            this.commandSystem = commandSystem;
+            this.sceneManagerSystem = sceneManagerSystem;
+            this.hierarchyOrderSystem = hierarchyOrderSystem;
+        }
+
+        public void AddEntityFromPresetAsCommand(EntityPresetState.EntityPreset preset, Guid parentId)
+        {
+            var newHierarchyOrder = hierarchyOrderSystem.GetDefaultHierarchyOrder(parentId);
+            
+            var scene = sceneManagerSystem.GetCurrentScene();
+            
+            if (scene == null)
+            {
+                return;
+            }
+            
+            commandSystem.ExecuteCommand(
+                commandSystem.CommandFactory.CreateAddEntity(
+                    preset,
+                    scene.SelectionState.PrimarySelectedEntity?.Id ?? Guid.Empty,
+                    scene.SelectionState.SecondarySelectedEntities.Select(e => e.Id),
+                    newHierarchyOrder, parentId));
+        }
+
+        public void AddModelAssetEntityAsCommand(DclEntity newEntity, AssetMetadata assetMetadata, Vector3 position)
+        {
+            var hierarchyOrder = hierarchyOrderSystem.GetDefaultHierarchyOrder(newEntity.ParentId);
+            
+            commandSystem.ExecuteCommand(commandSystem.CommandFactory.CreateAddModelAssetToScene(newEntity.Id,
+                newEntity.CustomName, assetMetadata.assetId, position, hierarchyOrder));
+        }
+
+        public void DuplicateEntityAsCommand(DclEntity selectedEntity)
+        {
+            var hierarchyOrder = hierarchyOrderSystem.GetDefaultHierarchyOrder(selectedEntity.ParentId);
+            
+            commandSystem.ExecuteCommand(commandSystem.CommandFactory.CreateDuplicateEntity(selectedEntity.Id, hierarchyOrder));
+        }
+    }
+}

--- a/Assets/Scripts/System/AddEntitySystem.cs
+++ b/Assets/Scripts/System/AddEntitySystem.cs
@@ -26,7 +26,7 @@ namespace Assets.Scripts.System
         {
             var newHierarchyOrder = hierarchyOrderSystem.GetDefaultHierarchyOrder(parentId);
             
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
             
             if (scene == null)
             {

--- a/Assets/Scripts/System/AddEntitySystem.cs
+++ b/Assets/Scripts/System/AddEntitySystem.cs
@@ -1,11 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using Assets.Scripts.Command.Utility;
 using Assets.Scripts.EditorState;
 using Assets.Scripts.SceneState;
-using Assets.Scripts.Utility;
-using UnityEditor;
 using UnityEngine;
 using Zenject;
 

--- a/Assets/Scripts/System/AddEntitySystem.cs.meta
+++ b/Assets/Scripts/System/AddEntitySystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 77093e0886894e649c9fc2f3610c6f11
+timeCreated: 1676560122

--- a/Assets/Scripts/System/CommandFactorySystem.cs
+++ b/Assets/Scripts/System/CommandFactorySystem.cs
@@ -49,7 +49,7 @@ public class CommandFactorySystem
     }
 
     // Duplicate Entity
-    public DuplicateEntity CreateDuplicateEntity(Guid entityId, float? hierarchyOrder)
+    public DuplicateEntity CreateDuplicateEntity(Guid entityId, float hierarchyOrder)
     {
         return new DuplicateEntity(entityId, hierarchyOrder);
     }

--- a/Assets/Scripts/System/CommandFactorySystem.cs
+++ b/Assets/Scripts/System/CommandFactorySystem.cs
@@ -49,14 +49,14 @@ public class CommandFactorySystem
     }
 
     // Duplicate Entity
-    public DuplicateEntity CreateDuplicateEntity(Guid entityId)
+    public DuplicateEntity CreateDuplicateEntity(Guid entityId, float? hierarchyOrder)
     {
-        return new DuplicateEntity(entityId);
+        return new DuplicateEntity(entityId, hierarchyOrder);
     }
 
-    public AddModelAssetToScene CreateAddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene)
+    public AddModelAssetToScene CreateAddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene, float? hierarchyOrder)
     {
-        return new AddModelAssetToScene(entityId, entityCustomName, assetId, positionInScene);
+        return new AddModelAssetToScene(entityId, entityCustomName, assetId, positionInScene, hierarchyOrder);
     }
 
     public AddComponent CreateAddComponent(Guid entityId, DclComponent.ComponentDefinition component)
@@ -69,14 +69,20 @@ public class CommandFactorySystem
         return new RemoveComponent(entityId, component);
     }
 
-    public AddEntity CreateAddEntity(EntityPresetState.EntityPreset preset, Guid oldPrimarySelection, IEnumerable<Guid> oldSecondarySelection, Guid parent = default)
+    public AddEntity CreateAddEntity(EntityPresetState.EntityPreset preset, Guid oldPrimarySelection,
+        IEnumerable<Guid> oldSecondarySelection, float? hierarchyOrder, Guid parent = default)
     {
-        return new AddEntity(oldPrimarySelection, oldSecondarySelection, preset, parent);
+        return new AddEntity(oldPrimarySelection, oldSecondarySelection, preset, hierarchyOrder, parent);
     }
 
     public RemoveEntity CreateRemoveEntity(DclEntity entity)
     {
         return new RemoveEntity(entity);
     }
-}
 
+    public ChangeHierarchyOrder CreateChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity,
+        HierarchyExpansionState hierarchyExpansionState, float? newHierarchyOrder, DclEntity newParent)
+    {
+        return new ChangeHierarchyOrder(draggedEntity, hoveredEntity, hierarchyExpansionState, newHierarchyOrder, newParent);
+    }
+}

--- a/Assets/Scripts/System/CommandFactorySystem.cs
+++ b/Assets/Scripts/System/CommandFactorySystem.cs
@@ -81,8 +81,9 @@ public class CommandFactorySystem
     }
 
     public ChangeHierarchyOrder CreateChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity,
-        HierarchyExpansionState hierarchyExpansionState, float newHierarchyOrder, DclEntity newParent)
+        HierarchyExpansionState hierarchyExpansionState, float newHierarchyOrder, DclEntity newParent,
+        bool shouldExpand)
     {
-        return new ChangeHierarchyOrder(draggedEntity, hoveredEntity, hierarchyExpansionState, newHierarchyOrder, newParent);
+        return new ChangeHierarchyOrder(draggedEntity, hoveredEntity, hierarchyExpansionState, newHierarchyOrder, newParent, shouldExpand);
     }
 }

--- a/Assets/Scripts/System/CommandFactorySystem.cs
+++ b/Assets/Scripts/System/CommandFactorySystem.cs
@@ -54,7 +54,7 @@ public class CommandFactorySystem
         return new DuplicateEntity(entityId, hierarchyOrder);
     }
 
-    public AddModelAssetToScene CreateAddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene, float? hierarchyOrder)
+    public AddModelAssetToScene CreateAddModelAssetToScene(Guid entityId, string entityCustomName, Guid assetId, Vector3 positionInScene, float hierarchyOrder)
     {
         return new AddModelAssetToScene(entityId, entityCustomName, assetId, positionInScene, hierarchyOrder);
     }
@@ -70,7 +70,7 @@ public class CommandFactorySystem
     }
 
     public AddEntity CreateAddEntity(EntityPresetState.EntityPreset preset, Guid oldPrimarySelection,
-        IEnumerable<Guid> oldSecondarySelection, float? hierarchyOrder, Guid parent = default)
+        IEnumerable<Guid> oldSecondarySelection, float hierarchyOrder, Guid parent = default)
     {
         return new AddEntity(oldPrimarySelection, oldSecondarySelection, preset, hierarchyOrder, parent);
     }
@@ -81,7 +81,7 @@ public class CommandFactorySystem
     }
 
     public ChangeHierarchyOrder CreateChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity,
-        HierarchyExpansionState hierarchyExpansionState, float? newHierarchyOrder, DclEntity newParent)
+        HierarchyExpansionState hierarchyExpansionState, float newHierarchyOrder, DclEntity newParent)
     {
         return new ChangeHierarchyOrder(draggedEntity, hoveredEntity, hierarchyExpansionState, newHierarchyOrder, newParent);
     }

--- a/Assets/Scripts/System/CommandFactorySystem.cs
+++ b/Assets/Scripts/System/CommandFactorySystem.cs
@@ -80,10 +80,8 @@ public class CommandFactorySystem
         return new RemoveEntity(entity);
     }
 
-    public ChangeHierarchyOrder CreateChangeHierarchyOrder(DclEntity draggedEntity, DclEntity hoveredEntity,
-        HierarchyExpansionState hierarchyExpansionState, float newHierarchyOrder, DclEntity newParent,
-        bool shouldExpand)
+    public ChangeHierarchyOrder CreateChangeHierarchyOrder(Guid affectedEntityId, Guid startParentId, float startHierarchyOrder, float newHierarchyOrder, Guid newParentId)
     {
-        return new ChangeHierarchyOrder(draggedEntity, hoveredEntity, hierarchyExpansionState, newHierarchyOrder, newParent, shouldExpand);
+        return new ChangeHierarchyOrder(affectedEntityId, startParentId, startHierarchyOrder, newHierarchyOrder, newParentId);
     }
 }

--- a/Assets/Scripts/System/CommandSystem.cs
+++ b/Assets/Scripts/System/CommandSystem.cs
@@ -32,7 +32,7 @@ namespace Assets.Scripts.System
             if (command == null)
                 return;
 
-            var commandState = sceneManagerSystem.GetCurrentScene()?.CommandHistoryState;
+            var commandState = sceneManagerSystem.GetCurrentSceneOrNull()?.CommandHistoryState;
 
             if (commandState == null)
             {
@@ -49,12 +49,12 @@ namespace Assets.Scripts.System
             commandState.CommandHistory.Add(command);
             commandState.CurrentCommandIndex = commandState.CommandHistory.Count - 1;
 
-            command.Do(sceneManagerSystem.GetCurrentScene(), editorEvents);
+            command.Do(sceneManagerSystem.GetCurrentSceneOrNull(), editorEvents);
         }
 
         public void UndoCommand()
         {
-            var commandState = sceneManagerSystem.GetCurrentScene()?.CommandHistoryState;
+            var commandState = sceneManagerSystem.GetCurrentSceneOrNull()?.CommandHistoryState;
 
             if (commandState == null)
             {
@@ -64,14 +64,14 @@ namespace Assets.Scripts.System
 
             if (commandState.CurrentCommandIndex >= 0)
             {
-                commandState.CommandHistory[commandState.CurrentCommandIndex].Undo(sceneManagerSystem.GetCurrentScene(), editorEvents);
+                commandState.CommandHistory[commandState.CurrentCommandIndex].Undo(sceneManagerSystem.GetCurrentSceneOrNull(), editorEvents);
                 commandState.CurrentCommandIndex--;
             }
         }
 
         public void RedoCommand()
         {
-            var commandState = sceneManagerSystem.GetCurrentScene()?.CommandHistoryState;
+            var commandState = sceneManagerSystem.GetCurrentSceneOrNull()?.CommandHistoryState;
 
             if (commandState == null)
             {
@@ -82,7 +82,7 @@ namespace Assets.Scripts.System
             if (commandState.CurrentCommandIndex < commandState.CommandHistory.Count - 1)
             {
                 commandState.CurrentCommandIndex++;
-                commandState.CommandHistory[commandState.CurrentCommandIndex].Do(sceneManagerSystem.GetCurrentScene(), editorEvents);
+                commandState.CommandHistory[commandState.CurrentCommandIndex].Do(sceneManagerSystem.GetCurrentSceneOrNull(), editorEvents);
             }
         }
 

--- a/Assets/Scripts/System/EntitySelectSystem.cs
+++ b/Assets/Scripts/System/EntitySelectSystem.cs
@@ -45,7 +45,7 @@ namespace Assets.Scripts.System
 
         public void SelectAdditional(Guid id)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
             if (scene == null)
             {
                 return;
@@ -64,7 +64,7 @@ namespace Assets.Scripts.System
 
         public void SelectSingle(Guid id)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
             if (scene == null)
             {
                 return;
@@ -81,7 +81,7 @@ namespace Assets.Scripts.System
 
         public void DeselectAll()
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
             if (scene == null)
             {
                 return;

--- a/Assets/Scripts/System/ExposeEntitySystem.cs
+++ b/Assets/Scripts/System/ExposeEntitySystem.cs
@@ -19,7 +19,7 @@ public class ExposeEntitySystem
 
     public bool IsEntityExposable(DclEntity entity)
     {
-        var scene = sceneManagerSystem.GetCurrentScene();
+        var scene = sceneManagerSystem.GetCurrentSceneOrNull();
         if (scene == null)
         {
             return false;

--- a/Assets/Scripts/System/HierarchyChangeSystem.cs
+++ b/Assets/Scripts/System/HierarchyChangeSystem.cs
@@ -7,32 +7,37 @@ namespace Assets.Scripts.System
     public class HierarchyChangeSystem
     {
         // Dependencies
-        private EntitySelectSystem _entitySelectSystem;
-        private HierarchyExpansionState _hierarchyExpansionState;
-        private EditorEvents _editorEvents;
+        private EntitySelectSystem entitySelectSystem;
+        private HierarchyExpansionState hierarchyExpansionState;
+        private EditorEvents editorEvents;
 
         [Inject]
         private void Construct(EntitySelectSystem entitySelectSystem, HierarchyExpansionState hierarchyExpansionState, EditorEvents editorEvents)
         {
-            _entitySelectSystem = entitySelectSystem;
-            _hierarchyExpansionState = hierarchyExpansionState;
-            _editorEvents = editorEvents;
+            this.entitySelectSystem = entitySelectSystem;
+            this.hierarchyExpansionState = hierarchyExpansionState;
+            this.editorEvents = editorEvents;
         }
 
         public void ClickedOnEntityInHierarchy(DclEntity entity)
         {
-            _entitySelectSystem.ClickedOnEntity(entity.Id);
+            entitySelectSystem.ClickedOnEntity(entity.Id);
         }
 
         public void ClickedOnEntityExpandArrow(DclEntity entity)
         {
-            _hierarchyExpansionState.ToggleExpanded(entity.Id);
-            _editorEvents.InvokeHierarchyChangedEvent();
+            hierarchyExpansionState.ToggleExpanded(entity.Id);
+            editorEvents.InvokeHierarchyChangedEvent();
+        }
+
+        public void SetExpanded(DclEntity entity, bool isExpanded)
+        {
+            hierarchyExpansionState.SetExpanded(entity.Id, isExpanded);
         }
 
         public bool IsExpanded(DclEntity entity)
         {
-            return _hierarchyExpansionState.IsExpanded(entity.Id);
+            return hierarchyExpansionState.IsExpanded(entity.Id);
         }
     }
 }

--- a/Assets/Scripts/System/HierarchyContextMenuSystem.cs
+++ b/Assets/Scripts/System/HierarchyContextMenuSystem.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Assets.Scripts.EditorState;
 using Zenject;
 
@@ -9,19 +8,16 @@ namespace Assets.Scripts.System
     public class HierarchyContextMenuSystem
     {
         // Dependencies
-        private CommandSystem commandSystem;
-        private SceneManagerSystem sceneManagerSystem;
         private EntityPresetSystem entityPresetSystem;
+        private AddEntitySystem addEntitySystem;
 
         [Inject]
         public void Construct(
-            CommandSystem commandSystem,
-            SceneManagerSystem sceneManagerSystem,
-            EntityPresetSystem entityPresetSystem)
+            EntityPresetSystem entityPresetSystem,
+            AddEntitySystem addEntitySystem)
         {
-            this.commandSystem = commandSystem;
-            this.sceneManagerSystem = sceneManagerSystem;
             this.entityPresetSystem = entityPresetSystem;
+            this.addEntitySystem = addEntitySystem;
         }
 
         public IEnumerable<EntityPresetState.EntityPreset> GetPresets()
@@ -31,18 +27,7 @@ namespace Assets.Scripts.System
 
         public void AddEntityFromPreset(EntityPresetState.EntityPreset preset, Guid parentId = default)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
-            if (scene == null)
-            {
-                return;
-            }
-
-            commandSystem.ExecuteCommand(
-                commandSystem.CommandFactory.CreateAddEntity(
-                    preset,
-                    scene.SelectionState.PrimarySelectedEntity?.Id ?? Guid.Empty,
-                    scene.SelectionState.SecondarySelectedEntities.Select(e => e.Id),
-                    parentId));
+            addEntitySystem.AddEntityFromPresetAsCommand(preset, parentId);
         }
     }
 }

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -90,14 +90,9 @@ namespace Assets.Scripts.System
         /// Gets the new calculated hierarchy order, when placing an entity below the last root entity.
         /// </summary>
         /// <returns>The calculated hierarchy order, or null</returns>
-        private float? GetNewHierarchyOrderPlaceLastInRoot()
+        private float GetNewHierarchyOrderPlaceLastInRoot()
         {
             var scene = sceneManagerSystem.GetCurrentScene();
-            
-            if (scene == null)
-            {
-                return null;
-            }
             
             var rootEntities = scene.EntitiesInSceneRoot.ToList();
             
@@ -111,7 +106,7 @@ namespace Assets.Scripts.System
         /// <param name="first">An existing entity</param>
         /// <param name="second">Another existing entity</param>
         /// <returns>The new calculated hierarchy order or the order of the entity</returns>
-        private static float? GetHierarchyOrderPlaceBetweenSiblings(DclEntity entity, DclEntity first, DclEntity second)
+        private static float GetHierarchyOrderPlaceBetweenSiblings(DclEntity entity, DclEntity first, DclEntity second)
         {
             if (entity == first || entity == second)
             {
@@ -125,7 +120,7 @@ namespace Assets.Scripts.System
         /// Gets the new calculated hierarchy order, when placing an entity as a child without existing siblings.
         /// </summary>
         /// <returns>The new calculated hierarchy order</returns>
-        private static float? GetHierarchyOrderPlaceAsOnlyChild()
+        private static float GetHierarchyOrderPlaceAsOnlyChild()
         {
             return 0.0f;
         }
@@ -135,7 +130,7 @@ namespace Assets.Scripts.System
         /// </summary>
         /// <param name="nextSiblingEntity">The existing sibling</param>
         /// <returns>The new calculated hierarchy order</returns>
-        private static float? GetHierarchyOrderPlaceAboveSibling(DclEntity nextSiblingEntity)
+        private static float GetHierarchyOrderPlaceAboveSibling(DclEntity nextSiblingEntity)
         {
             return nextSiblingEntity.hierarchyOrder - 1;
         }
@@ -145,7 +140,7 @@ namespace Assets.Scripts.System
         /// </summary>
         /// <param name="previousSiblingEntity">The existing sibling</param>
         /// <returns>The new calculated hierarchy order</returns>
-        private static float? GetHierarchyOrderPlaceBeneathSibling(DclEntity previousSiblingEntity)
+        private static float GetHierarchyOrderPlaceBeneathSibling(DclEntity previousSiblingEntity)
         {
             return previousSiblingEntity.hierarchyOrder + 1;
         }
@@ -159,12 +154,13 @@ namespace Assets.Scripts.System
         /// <param name="newHierarchyOrder">The future hierarchy order of the dragged Entity</param>
         /// <param name="newParent">The future parent of the dragged Entity</param>
         private void ChangeHierarchyOrderAsCommand(DclEntity draggedEntity, DclEntity hoveredEntity,
-            float? newHierarchyOrder, DclEntity newParent)
+            float newHierarchyOrder, DclEntity newParent)
         {
             if (newParent != null && newParent.Children.Any(e => e.hierarchyOrder.Equals(newHierarchyOrder)))
             {
                 Debug.LogError("Hierarchy order must be unique!");
             }
+            //TODO entity hierarchy order == newentityhierarchyOrder return
             
             commandSystem.ExecuteCommand(
                 commandSystem.CommandFactory.CreateChangeHierarchyOrder(draggedEntity, hoveredEntity,
@@ -176,19 +172,13 @@ namespace Assets.Scripts.System
         /// </summary>
         /// <param name="parentId">Id of the parent</param>
         /// <returns>The new calculated hierarchy order</returns>
-        private float? GetHierarchyOrderFromParentWhenPlacedAsLastChild(Guid parentId)
+        private float GetHierarchyOrderFromParentWhenPlacedAsLastChild(Guid parentId)
         {
             var scene = sceneManagerSystem.GetCurrentScene();
-            
-            if (scene == null)
-            {
-                Debug.LogError("No current scene!");
-                return null;
-            }
 
             var parent = scene.GetEntityById(parentId);
             
-            float? newHierarchyOrder;
+            float newHierarchyOrder;
 
             if (parent.Children.Any())
             {
@@ -209,9 +199,9 @@ namespace Assets.Scripts.System
         /// </summary>
         /// <param name="parentId">Id of the parent</param>
         /// <returns>The new calculated hierarchy order</returns>
-        public float? GetDefaultHierarchyOrder(Guid parentId)
+        public float GetDefaultHierarchyOrder(Guid parentId)
         {
-            float? newHierarchyOrder;
+            float newHierarchyOrder;
             
             if (parentId != default)
             {
@@ -233,13 +223,13 @@ namespace Assets.Scripts.System
         /// <param name="aboveEntity">The Entity, that is sibling above the hovered Entity</param>
         public void DropUpper(DclEntity draggedEntity, DclEntity hoveredEntity, DclEntity aboveEntity)
         {
-            if (aboveEntity == draggedEntity)
+            if (draggedEntity == aboveEntity)
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
             }
             
-            float? newHierarchyOrder;
+            float newHierarchyOrder;
 
             var newParent = hoveredEntity?.Parent;
 
@@ -271,7 +261,7 @@ namespace Assets.Scripts.System
             var newHierarchyOrder = GetHierarchyOrderFromParentWhenPlacedAsLastChild(hoveredEntity.Id);
             var newParent = hoveredEntity;
 
-            if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsSuccessorOf(draggedEntity)))
+            if (draggedEntity == null || hoveredEntity.IsSuccessorOf(draggedEntity))
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
@@ -291,7 +281,7 @@ namespace Assets.Scripts.System
         public void DropLower(DclEntity draggedEntity, DclEntity hoveredEntity, DclEntity belowEntity,
             DclEntity firstChildOfHoveredEntity, bool isExpanded)
         {
-            float? newHierarchyOrder;
+            float newHierarchyOrder;
             DclEntity newParent;
 
             if (belowEntity == draggedEntity)

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -241,9 +241,11 @@ namespace Assets.Scripts.System
         /// <param name="aboveEntity">The Entity, that is sibling above the hovered Entity</param>
         public void DropUpper(DclEntity draggedEntity, DclEntity hoveredEntity, DclEntity aboveEntity)
         {
+            Assert.IsNotNull(draggedEntity);
+            Assert.IsNotNull(hoveredEntity);
             Assert.AreNotEqual(draggedEntity, hoveredEntity);
 
-            if (draggedEntity == aboveEntity || draggedEntity == hoveredEntity)
+            if (draggedEntity == aboveEntity)
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
@@ -272,12 +274,14 @@ namespace Assets.Scripts.System
         /// <param name="hoveredEntity">The Entity, that is being dropped on</param>
         public void DropMiddle(DclEntity draggedEntity, DclEntity hoveredEntity)
         {
+            Assert.IsNotNull(draggedEntity);
+            Assert.IsNotNull(hoveredEntity);
             Assert.AreNotEqual(draggedEntity, hoveredEntity);
             
             var newHierarchyOrder = GetHierarchyOrderFromParentWhenPlacedAsLastChild(hoveredEntity.Id);
             var newParent = hoveredEntity;
 
-            if (draggedEntity == null || hoveredEntity.IsDescendantOf(draggedEntity))
+            if (hoveredEntity.IsDescendantOf(draggedEntity))
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
@@ -300,11 +304,13 @@ namespace Assets.Scripts.System
             float newHierarchyOrder;
             DclEntity newParent;
 
+            Assert.IsNotNull(draggedEntity);
+            Assert.IsNotNull(hoveredEntity);
             Assert.AreNotEqual(draggedEntity, hoveredEntity);
             
             if (isExpanded)
             {
-                if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsDescendantOf(draggedEntity)))
+                if (hoveredEntity.IsDescendantOf(draggedEntity))
                 {
                     editorEvents.InvokeHierarchyChangedEvent();
                     return;
@@ -338,6 +344,7 @@ namespace Assets.Scripts.System
         /// <param name="draggedEntity">The dragged Entity</param>
         public void DropSpacer(DclEntity draggedEntity)
         {
+            Assert.IsNotNull(draggedEntity);
             var newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot(draggedEntity);
 
             ChangeHierarchyOrderAsCommand(draggedEntity, null, newHierarchyOrder, null);

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -39,17 +39,12 @@ namespace Assets.Scripts.System
 
             if (parent == null)
             {
-                var scene = sceneManagerSystem.GetCurrentSceneOrNull();
-                children = scene?.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
+                var scene = sceneManagerSystem.GetCurrentScene();
+                children = scene.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
             }
             else
             {
                 children = parent.Children.OrderBy(e => e.hierarchyOrder).ToList();
-            }
-
-            if (children == null)
-            {
-                return null;
             }
 
             var index = children.IndexOf(entity);
@@ -69,17 +64,12 @@ namespace Assets.Scripts.System
 
             if (parent == null)
             {
-                var scene = sceneManagerSystem.GetCurrentSceneOrNull();
+                var scene = sceneManagerSystem.GetCurrentScene();
                 children = scene?.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
             }
             else
             {
                 children = parent.Children.OrderBy(e => e.hierarchyOrder).ToList();
-            }
-
-            if (children == null)
-            {
-                return null;
             }
 
             var index = children.IndexOf(entity);
@@ -92,7 +82,7 @@ namespace Assets.Scripts.System
         /// <returns>The calculated hierarchy order, or null</returns>
         private float GetNewHierarchyOrderPlaceLastInRoot()
         {
-            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
+            var scene = sceneManagerSystem.GetCurrentScene();
             
             var rootEntities = scene.EntitiesInSceneRoot.ToList();
             
@@ -175,7 +165,7 @@ namespace Assets.Scripts.System
         /// <returns>The new calculated hierarchy order</returns>
         private float GetHierarchyOrderFromParentWhenPlacedAsLastChild(Guid parentId)
         {
-            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
+            var scene = sceneManagerSystem.GetCurrentScene();
 
             var parent = scene.GetEntityById(parentId);
             

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -5,6 +5,7 @@ using Assets.Scripts.Events;
 using Assets.Scripts.SceneState;
 using JetBrains.Annotations;
 using UnityEngine;
+using UnityEngine.Assertions;
 using Zenject;
 
 namespace Assets.Scripts.System
@@ -240,6 +241,8 @@ namespace Assets.Scripts.System
         /// <param name="aboveEntity">The Entity, that is sibling above the hovered Entity</param>
         public void DropUpper(DclEntity draggedEntity, DclEntity hoveredEntity, DclEntity aboveEntity)
         {
+            Assert.AreNotEqual(draggedEntity, hoveredEntity);
+
             if (draggedEntity == aboveEntity || draggedEntity == hoveredEntity)
             {
                 editorEvents.InvokeHierarchyChangedEvent();
@@ -269,11 +272,7 @@ namespace Assets.Scripts.System
         /// <param name="hoveredEntity">The Entity, that is being dropped on</param>
         public void DropMiddle(DclEntity draggedEntity, DclEntity hoveredEntity)
         {
-            if (hoveredEntity == draggedEntity)
-            {
-                editorEvents.InvokeHierarchyChangedEvent();
-                return;
-            }
+            Assert.AreNotEqual(draggedEntity, hoveredEntity);
             
             var newHierarchyOrder = GetHierarchyOrderFromParentWhenPlacedAsLastChild(hoveredEntity.Id);
             var newParent = hoveredEntity;
@@ -301,11 +300,7 @@ namespace Assets.Scripts.System
             float newHierarchyOrder;
             DclEntity newParent;
 
-            if (draggedEntity == hoveredEntity)
-            {
-                editorEvents.InvokeHierarchyChangedEvent();
-                return;
-            }
+            Assert.AreNotEqual(draggedEntity, hoveredEntity);
             
             if (isExpanded)
             {

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -39,7 +39,7 @@ namespace Assets.Scripts.System
 
             if (parent == null)
             {
-                var scene = sceneManagerSystem.GetCurrentScene();
+                var scene = sceneManagerSystem.GetCurrentSceneOrNull();
                 children = scene?.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
             }
             else
@@ -69,7 +69,7 @@ namespace Assets.Scripts.System
 
             if (parent == null)
             {
-                var scene = sceneManagerSystem.GetCurrentScene();
+                var scene = sceneManagerSystem.GetCurrentSceneOrNull();
                 children = scene?.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
             }
             else
@@ -92,7 +92,7 @@ namespace Assets.Scripts.System
         /// <returns>The calculated hierarchy order, or null</returns>
         private float GetNewHierarchyOrderPlaceLastInRoot()
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
             
             var rootEntities = scene.EntitiesInSceneRoot.ToList();
             
@@ -175,7 +175,7 @@ namespace Assets.Scripts.System
         /// <returns>The new calculated hierarchy order</returns>
         private float GetHierarchyOrderFromParentWhenPlacedAsLastChild(Guid parentId)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             var parent = scene.GetEntityById(parentId);
             

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Assets.Scripts.Events;
+using Assets.Scripts.SceneState;
+using JetBrains.Annotations;
+using UnityEngine;
+using Zenject;
+
+namespace Assets.Scripts.System
+{
+    public class HierarchyOrderSystem
+    {
+        private CommandSystem commandSystem;
+        private HierarchyExpansionState hierarchyExpansionState;
+        private EditorEvents editorEvents;
+        private SceneManagerSystem sceneManagerSystem;
+
+        [Inject]
+        public void Construct(
+            CommandSystem commandSystem, HierarchyExpansionState hierarchyExpansionState, EditorEvents editorEvents, SceneManagerSystem sceneManagersystem)
+        {
+            this.commandSystem = commandSystem;
+            this.hierarchyExpansionState = hierarchyExpansionState;
+            this.editorEvents = editorEvents;
+            this.sceneManagerSystem = sceneManagersystem;
+        }
+
+        /// <summary>
+        /// Gets the sibling underneath the given entity, if there is one.
+        /// </summary>
+        /// <param name="entity">The entity to search from</param>
+        /// <returns>The sibling, or null</returns>
+        [CanBeNull]
+        public DclEntity GetBelowSibling(DclEntity entity)
+        {
+            var parent = entity.Parent;
+            List<DclEntity> children;
+
+            if (parent == null)
+            {
+                var scene = sceneManagerSystem.GetCurrentScene();
+                children = scene?.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
+            }
+            else
+            {
+                children = parent.Children.OrderBy(e => e.hierarchyOrder).ToList();
+            }
+
+            if (children == null)
+            {
+                return null;
+            }
+
+            var index = children.IndexOf(entity);
+            return (index + 1) >= children.Count ? null : children[index + 1];
+        }
+        
+        /// <summary>
+        /// Gets the sibling above the given entity, if there is one.
+        /// </summary>
+        /// <param name="entity">The entity to search from</param>
+        /// <returns>The sibling, or null</returns>
+        [CanBeNull]
+        public DclEntity GetAboveSibling(DclEntity entity)
+        {
+            var parent = entity.Parent;
+            List<DclEntity> children;
+
+            if (parent == null)
+            {
+                var scene = sceneManagerSystem.GetCurrentScene();
+                children = scene?.EntitiesInSceneRoot.OrderBy(e => e.hierarchyOrder).ToList();
+            }
+            else
+            {
+                children = parent.Children.OrderBy(e => e.hierarchyOrder).ToList();
+            }
+
+            if (children == null)
+            {
+                return null;
+            }
+
+            var index = children.IndexOf(entity);
+            return (index - 1) < 0 ? null : children[index - 1];
+        }
+
+        /// <summary>
+        /// Gets the new calculated hierarchy order, when placing an entity below the last root entity.
+        /// </summary>
+        /// <returns>The calculated hierarchy order, or null</returns>
+        private float? GetNewHierarchyOrderPlaceLastInRoot()
+        {
+            var scene = sceneManagerSystem.GetCurrentScene();
+            
+            if (scene == null)
+            {
+                return null;
+            }
+            
+            var rootEntities = scene.EntitiesInSceneRoot.ToList();
+            
+            return rootEntities.Count == 0 ? 0 : rootEntities.Max(e => e.hierarchyOrder) + 1;
+        }
+
+        /// <summary>
+        /// Gets the new calculated hierarchy order, when placing an entity between two siblings.
+        /// </summary>
+        /// <param name="entity">The entity to be placed</param>
+        /// <param name="first">An existing entity</param>
+        /// <param name="second">Another existing entity</param>
+        /// <returns>The new calculated hierarchy order or the order of the entity</returns>
+        private static float? GetHierarchyOrderPlaceBetweenSiblings(DclEntity entity, DclEntity first, DclEntity second)
+        {
+            if (entity == first || entity == second)
+            {
+                return entity.hierarchyOrder;
+            }
+
+            return 0.5f * (first.hierarchyOrder + second.hierarchyOrder);
+        }
+
+        /// <summary>
+        /// Gets the new calculated hierarchy order, when placing an entity as a child without existing siblings.
+        /// </summary>
+        /// <returns>The new calculated hierarchy order</returns>
+        private static float? GetHierarchyOrderPlaceAsOnlyChild()
+        {
+            return 0.0f;
+        }
+
+        /// <summary>
+        /// Gets the new calculated hierarchy order, when placing an entity above an existing sibling.
+        /// </summary>
+        /// <param name="nextSiblingEntity">The existing sibling</param>
+        /// <returns>The new calculated hierarchy order</returns>
+        private static float? GetHierarchyOrderPlaceAboveSibling(DclEntity nextSiblingEntity)
+        {
+            return nextSiblingEntity.hierarchyOrder - 1;
+        }
+
+        /// <summary>
+        /// Gets the new calculated hierarchy order, when placing an entity below an existing sibling.
+        /// </summary>
+        /// <param name="previousSiblingEntity">The existing sibling</param>
+        /// <returns>The new calculated hierarchy order</returns>
+        private static float? GetHierarchyOrderPlaceBeneathSibling(DclEntity previousSiblingEntity)
+        {
+            return previousSiblingEntity.hierarchyOrder + 1;
+        }
+
+
+        /// <summary>
+        /// Command to change the hierarchy order of an entity
+        /// </summary>
+        /// <param name="draggedEntity">The dragged Entity</param>
+        /// <param name="hoveredEntity">The Entity, that is being dropped on</param>
+        /// <param name="newHierarchyOrder">The future hierarchy order of the dragged Entity</param>
+        /// <param name="newParent">The future parent of the dragged Entity</param>
+        private void ChangeHierarchyOrderAsCommand(DclEntity draggedEntity, DclEntity hoveredEntity,
+            float? newHierarchyOrder, DclEntity newParent)
+        {
+            if (newParent != null && newParent.Children.Any(e => e.hierarchyOrder.Equals(newHierarchyOrder)))
+            {
+                Debug.LogError("Hierarchy order must be unique!");
+            }
+            
+            commandSystem.ExecuteCommand(
+                commandSystem.CommandFactory.CreateChangeHierarchyOrder(draggedEntity, hoveredEntity,
+                    hierarchyExpansionState, newHierarchyOrder, newParent));
+        }
+
+        /// <summary>
+        /// Gets the new calculated hierarchy order, when placing an entity as the last child of a given parent.
+        /// </summary>
+        /// <param name="parentId">Id of the parent</param>
+        /// <returns>The new calculated hierarchy order</returns>
+        private float? GetHierarchyOrderFromParentWhenPlacedAsLastChild(Guid parentId)
+        {
+            var scene = sceneManagerSystem.GetCurrentScene();
+            
+            if (scene == null)
+            {
+                Debug.LogError("No current scene!");
+                return null;
+            }
+
+            var parent = scene.GetEntityById(parentId);
+            
+            float? newHierarchyOrder;
+
+            if (parent.Children.Any())
+            {
+                var lastChild = parent.Children.OrderBy(e => e.hierarchyOrder).Last();
+                newHierarchyOrder = GetHierarchyOrderPlaceBeneathSibling(lastChild);
+            }
+            else
+            {
+                newHierarchyOrder = GetHierarchyOrderPlaceAsOnlyChild();
+            }
+
+            return newHierarchyOrder;
+        }
+        
+        /// <summary>
+        /// Gets the newly calculated default hierarchy order, using the parent.
+        /// This is the new highest hierarchy order in the layer the child will be placed in.
+        /// </summary>
+        /// <param name="parentId">Id of the parent</param>
+        /// <returns>The new calculated hierarchy order</returns>
+        public float? GetDefaultHierarchyOrder(Guid parentId)
+        {
+            float? newHierarchyOrder;
+            
+            if (parentId != default)
+            {
+                newHierarchyOrder = GetHierarchyOrderFromParentWhenPlacedAsLastChild(parentId);
+            }
+            else
+            {
+                newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot();
+            }
+
+            return newHierarchyOrder;
+        }
+        
+        /// <summary>
+        /// Handles dropping an entity onto the "top-zone" of a hierarchy item game object
+        /// </summary>
+        /// <param name="draggedEntity">The dragged Entity</param>
+        /// <param name="hoveredEntity">The Entity, that is being dropped on</param>
+        /// <param name="aboveEntity">The Entity, that is sibling above the hovered Entity</param>
+        public void DropUpper(DclEntity draggedEntity, DclEntity hoveredEntity, DclEntity aboveEntity)
+        {
+            if (aboveEntity == draggedEntity)
+            {
+                editorEvents.InvokeHierarchyChangedEvent();
+                return;
+            }
+            
+            float? newHierarchyOrder;
+
+            var newParent = hoveredEntity?.Parent;
+
+            if (aboveEntity == null)
+            {
+                newHierarchyOrder = GetHierarchyOrderPlaceAboveSibling(hoveredEntity);
+            }
+            else
+            {
+                newHierarchyOrder = GetHierarchyOrderPlaceBetweenSiblings(draggedEntity, hoveredEntity, aboveEntity);
+            }
+
+            ChangeHierarchyOrderAsCommand(draggedEntity, hoveredEntity, newHierarchyOrder, newParent);
+        }
+
+        /// <summary>
+        /// Handles dropping an entity onto the "middle-zone" of a hierarchy item game object
+        /// </summary>
+        /// <param name="draggedEntity">The dragged Entity</param>
+        /// <param name="hoveredEntity">The Entity, that is being dropped on</param>
+        public void DropMiddle(DclEntity draggedEntity, DclEntity hoveredEntity)
+        {
+            if (hoveredEntity == draggedEntity)
+            {
+                editorEvents.InvokeHierarchyChangedEvent();
+                return;
+            }
+            
+            var newHierarchyOrder = GetHierarchyOrderFromParentWhenPlacedAsLastChild(hoveredEntity.Id);
+            var newParent = hoveredEntity;
+
+            if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsSuccessorOf(draggedEntity)))
+            {
+                editorEvents.InvokeHierarchyChangedEvent();
+                return;
+            }
+
+            ChangeHierarchyOrderAsCommand(draggedEntity, hoveredEntity, newHierarchyOrder, newParent);
+        }
+        /// <summary>
+        /// Handles dropping an entity onto the "lower-zone" of a hierarchy item game object
+        /// </summary>
+        /// <param name="draggedEntity">The dragged Entity</param>
+        /// <param name="hoveredEntity">The Entity, that is being dropped on</param>
+        /// <param name="belowEntity">The Entity, that is the sibling below the hovered Entity</param>
+        /// <param name="firstChildOfHoveredEntity">The Entity, that is the first child of the hovered Entity</param>
+        /// <param name="isExpanded">Whether the hovered Entity is expanded or not</param>
+        
+        public void DropLower(DclEntity draggedEntity, DclEntity hoveredEntity, DclEntity belowEntity,
+            DclEntity firstChildOfHoveredEntity, bool isExpanded)
+        {
+            float? newHierarchyOrder;
+            DclEntity newParent;
+
+            if (belowEntity == draggedEntity)
+            {
+                editorEvents.InvokeHierarchyChangedEvent();
+                return;
+            }
+            
+            if (isExpanded)
+            {
+                if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsSuccessorOf(draggedEntity)))
+                {
+                    editorEvents.InvokeHierarchyChangedEvent();
+                    return;
+                }
+
+                newHierarchyOrder = GetHierarchyOrderPlaceAboveSibling(firstChildOfHoveredEntity);
+                newParent = hoveredEntity;
+            }
+            else if (belowEntity == null)
+            {
+                newHierarchyOrder = GetHierarchyOrderPlaceBeneathSibling(hoveredEntity);
+                newParent = hoveredEntity?.Parent;
+            }
+            else
+            {
+                newHierarchyOrder = GetHierarchyOrderPlaceBetweenSiblings(draggedEntity, hoveredEntity, belowEntity);
+                newParent = hoveredEntity?.Parent;
+            }
+
+            ChangeHierarchyOrderAsCommand(draggedEntity, hoveredEntity, newHierarchyOrder, newParent);
+        }
+
+        /// <summary>
+        /// Handles dropping an entity onto the dropzone of a spacer game object
+        /// </summary>
+        /// <param name="draggedEntity">The dragged Entity</param>
+        public void DropSpacer(DclEntity draggedEntity)
+        {
+            var newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot();
+
+            ChangeHierarchyOrderAsCommand(draggedEntity, null, newHierarchyOrder, null);
+        }
+    }
+}

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -105,7 +105,7 @@ namespace Assets.Scripts.System
         /// <param name="first">An existing entity</param>
         /// <param name="second">Another existing entity</param>
         /// <returns>The new calculated hierarchy order or the order of the entity</returns>
-        private static float GetHierarchyOrderPlaceBetweenSiblings(DclEntity first, DclEntity second)
+        public float GetHierarchyOrderPlaceBetweenSiblings(DclEntity first, DclEntity second)
         {
             return 0.5f * (first.hierarchyOrder + second.hierarchyOrder);
         }
@@ -134,7 +134,7 @@ namespace Assets.Scripts.System
         /// </summary>
         /// <param name="previousSiblingEntity">The existing sibling</param>
         /// <returns>The new calculated hierarchy order</returns>
-        private static float GetHierarchyOrderPlaceBeneathSibling(DclEntity previousSiblingEntity)
+        public float GetHierarchyOrderPlaceBeneathSibling(DclEntity previousSiblingEntity)
         {
             return previousSiblingEntity.hierarchyOrder + 1;
         }

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -287,7 +287,7 @@ namespace Assets.Scripts.System
             float newHierarchyOrder;
             DclEntity newParent;
 
-            if (draggedEntity == belowEntity || draggedEntity == hoveredEntity)
+            if (draggedEntity == hoveredEntity)
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
@@ -303,6 +303,11 @@ namespace Assets.Scripts.System
 
                 newHierarchyOrder = GetHierarchyOrderPlaceAboveSibling(firstChildOfHoveredEntity);
                 newParent = hoveredEntity;
+            }
+            else if (draggedEntity == belowEntity)
+            {
+                editorEvents.InvokeHierarchyChangedEvent();
+                return;
             }
             else if (belowEntity == null)
             {

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -80,13 +80,27 @@ namespace Assets.Scripts.System
         /// Gets the new calculated hierarchy order, when placing an entity below the last root entity.
         /// </summary>
         /// <returns>The calculated hierarchy order, or null</returns>
-        private float GetNewHierarchyOrderPlaceLastInRoot()
+        private float GetNewHierarchyOrderPlaceLastInRoot([CanBeNull] DclEntity draggedEntity)
         {
             var scene = sceneManagerSystem.GetCurrentScene();
             
             var rootEntities = scene.EntitiesInSceneRoot.ToList();
             
-            return rootEntities.Count == 0 ? 0 : rootEntities.Max(e => e.hierarchyOrder) + 1;
+            var lastEntityInRoot = rootEntities.OrderByDescending(e => e.hierarchyOrder).FirstOrDefault();
+
+            //No existing entities in root
+            if (lastEntityInRoot == null)
+            {
+                return 0;
+            }
+            
+            //If draggedEntity already exists as last sibling, return same hierarchy order
+            if (draggedEntity != null && draggedEntity.Id.Equals(lastEntityInRoot.Id))
+            {
+                return draggedEntity.hierarchyOrder;
+            }
+            
+            return lastEntityInRoot.hierarchyOrder + 1;
         }
 
         /// <summary>
@@ -212,7 +226,7 @@ namespace Assets.Scripts.System
             }
             else
             {
-                newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot();
+                newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot(null);
             }
 
             return newHierarchyOrder;
@@ -329,7 +343,7 @@ namespace Assets.Scripts.System
         /// <param name="draggedEntity">The dragged Entity</param>
         public void DropSpacer(DclEntity draggedEntity)
         {
-            var newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot();
+            var newHierarchyOrder = GetNewHierarchyOrderPlaceLastInRoot(draggedEntity);
 
             ChangeHierarchyOrderAsCommand(draggedEntity, null, newHierarchyOrder, null);
         }

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -145,7 +145,7 @@ namespace Assets.Scripts.System
                 Debug.LogError("Hierarchy order must be unique!");
             }
             
-            if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsSuccessorOf(draggedEntity)))
+            if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsDescendantOf(draggedEntity)))
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
@@ -252,7 +252,7 @@ namespace Assets.Scripts.System
             var newHierarchyOrder = GetHierarchyOrderFromParentWhenPlacedAsLastChild(hoveredEntity.Id);
             var newParent = hoveredEntity;
 
-            if (draggedEntity == null || hoveredEntity.IsSuccessorOf(draggedEntity))
+            if (draggedEntity == null || hoveredEntity.IsDescendantOf(draggedEntity))
             {
                 editorEvents.InvokeHierarchyChangedEvent();
                 return;
@@ -283,7 +283,7 @@ namespace Assets.Scripts.System
             
             if (isExpanded)
             {
-                if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsSuccessorOf(draggedEntity)))
+                if (draggedEntity == null || (hoveredEntity != null && hoveredEntity.IsDescendantOf(draggedEntity)))
                 {
                     editorEvents.InvokeHierarchyChangedEvent();
                     return;

--- a/Assets/Scripts/System/HierarchyOrderSystem.cs.meta
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 18311a420fe847d0874a70c400f71be1
+timeCreated: 1674585438

--- a/Assets/Scripts/System/LoadFromVersion1System.cs
+++ b/Assets/Scripts/System/LoadFromVersion1System.cs
@@ -76,12 +76,11 @@ namespace Assets.Scripts.System
             var uniqueNumbers = new Dictionary<int, DclEntity>();
             foreach (var entity in entities.entities)
             {
-                var newEntity = new DclEntity(Guid.NewGuid(), entity.name);
+                var newEntity = new DclEntity(Guid.NewGuid(), entity.name, hierarchyOrder: entity.hierarchyOrder);
 
 
                 //newEntity.IsExposed = entity.exposed;
 
-                //newEntity.HierarchyOrder = entity.hierarchyOrder;
                 //newEntity.CollapsedChildren = entity.collapsedChildren;
 
                 parentNumbers.Add(newEntity, entity.parent);

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using UnityEngine;
 using Zenject;
 using Debug = UnityEngine.Debug;
+using Random = System.Random;
 
 namespace Assets.Scripts.System
 {
@@ -207,7 +208,7 @@ namespace Assets.Scripts.System
             public string customName;
             public Guid guid;
             public Guid? parentGuid;
-            public float hierarchyOrder;
+            public float? hierarchyOrder;
             public bool isExposed;
             public List<DclComponentData> components;
             public string dclEditVersionNumber;
@@ -241,7 +242,9 @@ namespace Assets.Scripts.System
                     throw new SceneLoadException($"Guid was not set for entity {customName}");
                 }
 
-                var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed, hierarchyOrder);
+                hierarchyOrder ??= new Random().Next();
+                
+                var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed, (float)hierarchyOrder);
 
                 // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator 
                 foreach (var component in components)

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -207,6 +207,7 @@ namespace Assets.Scripts.System
             public string customName;
             public Guid guid;
             public Guid? parentGuid;
+            public float? hierarchyOrder;
             public bool isExposed;
             public List<DclComponentData> components;
             public string dclEditVersionNumber;
@@ -218,6 +219,7 @@ namespace Assets.Scripts.System
                 this.parentGuid = entity.Parent?.Id;
                 isExposed = entity.IsExposed;
                 dclEditVersionNumber = Application.version;
+                this.hierarchyOrder = entity.hierarchyOrder;
 
                 this.components = new List<DclComponentData>();
                 foreach (DclComponent component in entity.Components)
@@ -240,7 +242,7 @@ namespace Assets.Scripts.System
                 }
 
 
-                var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed);
+                var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed, hierarchyOrder);
 
                 // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator 
                 foreach (var component in components)

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -9,7 +9,7 @@ using System.Linq;
 using UnityEngine;
 using Zenject;
 using Debug = UnityEngine.Debug;
-using Random = System.Random;
+using Random = UnityEngine.Random;
 
 namespace Assets.Scripts.System
 {
@@ -257,8 +257,8 @@ namespace Assets.Scripts.System
                     throw new SceneLoadException($"Guid was not set for entity {customName}");
                 }
 
-                hierarchyOrder ??= new Random().Next();
-                
+                hierarchyOrder ??= Random.Range(0, 100000); // using full integer values for random initialization
+
                 var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed, (float)hierarchyOrder);
 
                 // ReSharper disable once ForeachCanBePartlyConvertedToQueryUsingAnotherGetEnumerator 

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -207,7 +207,7 @@ namespace Assets.Scripts.System
             public string customName;
             public Guid guid;
             public Guid? parentGuid;
-            public float? hierarchyOrder;
+            public float hierarchyOrder;
             public bool isExposed;
             public List<DclComponentData> components;
             public string dclEditVersionNumber;
@@ -240,12 +240,6 @@ namespace Assets.Scripts.System
                 {
                     throw new SceneLoadException($"Guid was not set for entity {customName}");
                 }
-                
-                if (hierarchyOrder == null)
-                {
-                    throw new SceneLoadException($"HierarchyOrder was not set for entity {customName}");
-                }
-
 
                 var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed, hierarchyOrder);
 

--- a/Assets/Scripts/System/SceneLoadSaveSystem.cs
+++ b/Assets/Scripts/System/SceneLoadSaveSystem.cs
@@ -240,6 +240,11 @@ namespace Assets.Scripts.System
                 {
                     throw new SceneLoadException($"Guid was not set for entity {customName}");
                 }
+                
+                if (hierarchyOrder == null)
+                {
+                    throw new SceneLoadException($"HierarchyOrder was not set for entity {customName}");
+                }
 
 
                 var dclEntity = new DclEntity(guid, customName, parentGuid ?? default, isExposed, hierarchyOrder);

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -280,7 +280,7 @@ namespace Assets.Scripts.System
         }
 
         [CanBeNull]
-        public DclScene GetCurrentScene()
+        public DclScene GetCurrentSceneOrNull()
         {
             //return null if no scene is open
             if (sceneManagerState.currentSceneIndex == Guid.Empty)

--- a/Assets/Scripts/System/SceneManagerSystem.cs
+++ b/Assets/Scripts/System/SceneManagerSystem.cs
@@ -290,6 +290,18 @@ namespace Assets.Scripts.System
 
             return GetScene(sceneManagerState.currentSceneIndex);
         }
+        
+        [NotNull]
+        public DclScene GetCurrentScene()
+        {
+            //return null if no scene is open
+            if (sceneManagerState.currentSceneIndex == Guid.Empty)
+            {
+                throw new NoCurrentSceneException();
+            }
+
+            return GetScene(sceneManagerState.currentSceneIndex);
+        }
 
         [NotNull]
         public DclScene GetScene(Guid id)
@@ -367,5 +379,16 @@ namespace Assets.Scripts.System
             public JObject settings;
             public string dclEditVersionNumber;
         }
+    }
+    
+    public class NoCurrentSceneException : Exception
+    {
+        public NoCurrentSceneException() { }
+
+        public NoCurrentSceneException(string message)
+            : base(message) { }
+
+        public NoCurrentSceneException(string message, Exception inner)
+            : base(message, inner) { }
     }
 }

--- a/Assets/Scripts/System/UpdatePropertiesFromUiSystem.cs
+++ b/Assets/Scripts/System/UpdatePropertiesFromUiSystem.cs
@@ -54,7 +54,7 @@ namespace Assets.Scripts.System
 
         public void UpdateFloatingProperty<T>(DclPropertyIdentifier property, T value)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             if (scene == null)
             {
@@ -68,7 +68,7 @@ namespace Assets.Scripts.System
 
         public void RevertFloatingProperty(DclPropertyIdentifier property)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             if (scene == null)
             {
@@ -82,7 +82,7 @@ namespace Assets.Scripts.System
 
         public void UpdateFixedProperty<T>(DclPropertyIdentifier property, T value)
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             if (scene == null)
             {

--- a/Assets/Scripts/Tests/PlayModeTests/UiTests/ShowAllBasicAtoms.cs
+++ b/Assets/Scripts/Tests/PlayModeTests/UiTests/ShowAllBasicAtoms.cs
@@ -14,7 +14,7 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
 {
     public class ShowAllBasicAtoms
     {
-        private bool sceneIsLoaded = false;
+        /*private bool sceneIsLoaded = false;
         private UiBuilder uiBuilder;
 
         [UnitySetUp]
@@ -201,6 +201,6 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             uiBuilder.Update(mainPanel);
 
             yield return testerPrompt.WaitForQuestionPrompt("Do you see three hierarchy items under each other?", Yes);
-        }
+        }*/
     }
 }

--- a/Assets/Scripts/Tests/PlayModeTests/UiTests/ShowAllBasicAtoms.cs
+++ b/Assets/Scripts/Tests/PlayModeTests/UiTests/ShowAllBasicAtoms.cs
@@ -14,7 +14,7 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
 {
     public class ShowAllBasicAtoms
     {
-        /*private bool sceneIsLoaded = false;
+        private bool sceneIsLoaded = false;
         private UiBuilder uiBuilder;
 
         [UnitySetUp]
@@ -201,6 +201,6 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             uiBuilder.Update(mainPanel);
 
             yield return testerPrompt.WaitForQuestionPrompt("Do you see three hierarchy items under each other?", Yes);
-        }*/
+        }
     }
 }

--- a/Assets/Scripts/Tests/PlayModeTests/UiTests/ShowAllBasicAtoms.cs
+++ b/Assets/Scripts/Tests/PlayModeTests/UiTests/ShowAllBasicAtoms.cs
@@ -71,7 +71,7 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             thirdPanel.AddBooleanProperty("Bool property", true, new StringPropertyAtom.UiPropertyActions<bool>());
 
             mainPanel.AddSpacer(100);
-            mainPanel.AddHierarchyItem("Hierarchy Item", 0, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), null);
+            mainPanel.AddHierarchyItem("Hierarchy Item", 0, false, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), null, null, null, null);
 
             centerUiBuilder.Update(mainPanel);
 
@@ -194,9 +194,9 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             var testerPrompt = UiTester.instance.uiTesterPrompt;
             var mainPanel = UiBuilder.NewPanelData();
 
-            mainPanel.AddHierarchyItem("This is some header", 0, true, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("This is some more header", 1, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("This is even more header", 1, false, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
+            mainPanel.AddHierarchyItem("This is some header", 0, true, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("This is some more header", 1, true, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("This is even more header", 1, false, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
 
             uiBuilder.Update(mainPanel);
 

--- a/Assets/Scripts/Tests/PlayModeTests/UiTests/TestHierarchyItem.cs
+++ b/Assets/Scripts/Tests/PlayModeTests/UiTests/TestHierarchyItem.cs
@@ -11,7 +11,7 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
 {
     public class TestHierarchyItem
     {
-        /*private bool sceneIsLoaded = false;
+        private bool sceneIsLoaded = false;
         private UiBuilder uiBuilder;
 
         [UnitySetUp]
@@ -225,6 +225,6 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
                 yield return testerPrompt.WaitForQuestionPrompt("Try to click the arrow, the text, and right click the text. Did anything happen?", No);
                 //yield return UiTester.instance.PositiveFeedback();
             }
-        }*/
+        }
     }
 }

--- a/Assets/Scripts/Tests/PlayModeTests/UiTests/TestHierarchyItem.cs
+++ b/Assets/Scripts/Tests/PlayModeTests/UiTests/TestHierarchyItem.cs
@@ -44,9 +44,9 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             var testerPrompt = UiTester.instance.uiTesterPrompt;
             var mainPanel = UiBuilder.NewPanelData();
 
-            mainPanel.AddHierarchyItem("This is some header", 0, true, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("This is some more header", 1, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("This is even more header", 1, false, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
+            mainPanel.AddHierarchyItem("This is some header", 0, true, true, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("This is some more header", 1, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("This is even more header", 1, false, true, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
 
             uiBuilder.Update(mainPanel);
 
@@ -59,22 +59,22 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             var testerPrompt = UiTester.instance.uiTesterPrompt;
             var mainPanel = UiBuilder.NewPanelData();
 
-            mainPanel.AddHierarchyItem("Level 0", 0, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 0", 0, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 1", 1, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 1", 1, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 2", 2, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 2", 2, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 3", 3, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 3", 3, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 4", 4, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 4", 4, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 5", 5, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 5", 5, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 6", 6, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 6", 6, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 7", 7, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Level 7", 7, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
+            mainPanel.AddHierarchyItem("Level 0", 0, false, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 0", 0, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 1", 1, false, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 1", 1, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 2", 2, false, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 2", 2, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 3", 3, false, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 3", 3, true, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 4", 4, false, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 4", 4, true, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 5", 5, false, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 5", 5, true, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 6", 6, false, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 6", 6, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 7", 7, false, false,false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Level 7", 7, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
 
             uiBuilder.Update(mainPanel);
 
@@ -87,9 +87,9 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
             var testerPrompt = UiTester.instance.uiTesterPrompt;
             var mainPanel = UiBuilder.NewPanelData();
 
-            mainPanel.AddHierarchyItem("Item", 0, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Item", 1, false, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Item", 2, false, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
+            mainPanel.AddHierarchyItem("Item", 0, false, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Item", 1, false, true, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Item", 2, false, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
 
             uiBuilder.Update(mainPanel);
 
@@ -98,9 +98,9 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
 
             mainPanel.childDates.Clear();
 
-            mainPanel.AddHierarchyItem("Item", 0, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Item", 1, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Item", 2, true, false, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
+            mainPanel.AddHierarchyItem("Item", 0, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Item", 1, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Item", 2, true, false, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
 
             uiBuilder.Update(mainPanel);
 
@@ -112,9 +112,9 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
 
             mainPanel.childDates.Clear();
 
-            mainPanel.AddHierarchyItem("Item", 0, true, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Item", 1, true, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
-            mainPanel.AddHierarchyItem("Item", 2, true, true, TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { });
+            mainPanel.AddHierarchyItem("Item", 0, true, true, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Item", 1, true, true, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
+            mainPanel.AddHierarchyItem("Item", 2, true, true, false,TextHandler.TextStyle.Normal, new HierarchyItemHandler.UiHierarchyItemActions(), _ => { }, _ => { }, _ => { }, _ => { });
 
             uiBuilder.Update(mainPanel);
 
@@ -137,13 +137,15 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
                     0,
                     true,
                     false,
+                    false,
                     TextHandler.TextStyle.Normal,
                     new HierarchyItemHandler.UiHierarchyItemActions
                     {
                         onArrowClick = () => clickChecker.Success(),
                         onNameClick = () => clickChecker.Fail("The user clicked on the text")
                     },
-                    _ => clickChecker.Fail("The user right clicked"));
+                    _ => clickChecker.Fail("The user right clicked"),
+                    _ => { }, _ => { }, _ => { });
 
                 uiBuilder.Update(mainPanel);
 
@@ -160,13 +162,15 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
                     0,
                     true,
                     false,
+                    false,
                     TextHandler.TextStyle.Normal,
                     new HierarchyItemHandler.UiHierarchyItemActions
                     {
                         onArrowClick = () => clickChecker.Fail("The user clicked on the arrow"),
                         onNameClick = () => clickChecker.Success()
                     },
-                    _ => clickChecker.Fail("The user right clicked"));
+                    _ => clickChecker.Fail("The user right clicked"),
+                    _ => { }, _ => { }, _ => { });
 
                 uiBuilder.Update(mainPanel);
 
@@ -183,13 +187,15 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
                     0,
                     true,
                     false,
+                    false,
                     TextHandler.TextStyle.Normal,
                     new HierarchyItemHandler.UiHierarchyItemActions
                     {
                         onArrowClick = () => clickChecker.Fail("The user clicked on the arrow"),
                         onNameClick = () => clickChecker.Fail("The user clicked on the text")
                     },
-                    _ => clickChecker.Success());
+                    _ => clickChecker.Success(),
+                    _ => { }, _ => { }, _ => { });
 
                 uiBuilder.Update(mainPanel);
 
@@ -205,13 +211,14 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
                     0,
                     true,
                     false,
+                    false,
                     TextHandler.TextStyle.Normal,
                     new HierarchyItemHandler.UiHierarchyItemActions
                     {
                         onArrowClick = null,
                         onNameClick = null
                     },
-                    null);
+                    null, null, null, null);
 
                 uiBuilder.Update(mainPanel);
 

--- a/Assets/Scripts/Tests/PlayModeTests/UiTests/TestHierarchyItem.cs
+++ b/Assets/Scripts/Tests/PlayModeTests/UiTests/TestHierarchyItem.cs
@@ -11,7 +11,7 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
 {
     public class TestHierarchyItem
     {
-        private bool sceneIsLoaded = false;
+        /*private bool sceneIsLoaded = false;
         private UiBuilder uiBuilder;
 
         [UnitySetUp]
@@ -218,6 +218,6 @@ namespace Assets.Scripts.Tests.PlayModeTests.UiTests
                 yield return testerPrompt.WaitForQuestionPrompt("Try to click the arrow, the text, and right click the text. Did anything happen?", No);
                 //yield return UiTester.instance.PositiveFeedback();
             }
-        }
+        }*/
     }
 }

--- a/Assets/Scripts/Visuals/DialogVisuals.cs
+++ b/Assets/Scripts/Visuals/DialogVisuals.cs
@@ -64,7 +64,7 @@ public class DialogVisuals : MonoBehaviour, IPointerEnterHandler, IPointerExitHa
         AssetDialogHandler handler = window.GetComponent<AssetDialogHandler>();
         handler.assetBrowserVisuals.assetButtonOnClickOverride = (Guid assetId) =>
         {
-            DclScene scene = sceneManagerSystem.GetCurrentScene();
+            DclScene scene = sceneManagerSystem.GetCurrentSceneOrNull();
             DclEntity entity = scene.GetEntityById(dialogState.targetEntityId);
             var shapeComponent = entity.GetComponentBySlot("Shape");
             if (shapeComponent != null) entity.RemoveComponent(shapeComponent);

--- a/Assets/Scripts/Visuals/EntityVisuals.cs
+++ b/Assets/Scripts/Visuals/EntityVisuals.cs
@@ -166,7 +166,7 @@ namespace Assets.Scripts.Visuals
                 return;
             }
 
-            DclScene rootScene = sceneManagerSystem.GetCurrentScene();
+            DclScene rootScene = sceneManagerSystem.GetCurrentSceneOrNull();
             if (rootScene == null)
             {
                 return;

--- a/Assets/Scripts/Visuals/GizmoVisuals.cs
+++ b/Assets/Scripts/Visuals/GizmoVisuals.cs
@@ -52,7 +52,7 @@ namespace Assets.Scripts.Visuals
         private void UpdateVisuals()
         {
             var selectedEntity = sceneManagerSystem
-                .GetCurrentScene()?
+                .GetCurrentSceneOrNull()?
                 .SelectionState
                 .PrimarySelectedEntity;
 

--- a/Assets/Scripts/Visuals/GltfShapeVisuals.cs
+++ b/Assets/Scripts/Visuals/GltfShapeVisuals.cs
@@ -76,7 +76,7 @@ namespace Assets.Scripts.Visuals
                 UpdateSelection(entity);
             }
 
-            if (_sceneManagerSystem.GetCurrentScene()?.IsFloatingEntity(entity.Id)! == true)
+            if (_sceneManagerSystem.GetCurrentSceneOrNull()?.IsFloatingEntity(entity.Id)! == true)
             {
                 StaticUtilities.SetLayerRecursive(gameObject, LayerMask.NameToLayer("Ignore Raycast"));
             }

--- a/Assets/Scripts/Visuals/ShapeVisuals.cs
+++ b/Assets/Scripts/Visuals/ShapeVisuals.cs
@@ -27,7 +27,7 @@ namespace Assets.Scripts.Visuals
 
         protected void UpdateSelection(DclEntity entity)
         {
-            var selectionState = sceneManagerSystem.GetCurrentScene()?.SelectionState;
+            var selectionState = sceneManagerSystem.GetCurrentSceneOrNull()?.SelectionState;
 
             if (selectionState == null)
             {

--- a/Assets/Scripts/Visuals/TemporaryEntityVisuals.cs
+++ b/Assets/Scripts/Visuals/TemporaryEntityVisuals.cs
@@ -33,7 +33,7 @@ namespace Assets.Scripts.Visuals
 
         private void UpdateVisuals()
         {
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             if (scene == null)
             {

--- a/Assets/Scripts/Visuals/UiBuilder/HierarchyItemAtom.cs
+++ b/Assets/Scripts/Visuals/UiBuilder/HierarchyItemAtom.cs
@@ -1,4 +1,5 @@
 using System;
+using Assets.Scripts.SceneState;
 using Assets.Scripts.Visuals.UiHandler;
 using UnityEngine;
 
@@ -12,9 +13,12 @@ namespace Assets.Scripts.Visuals.UiBuilder
             public int level;
             public bool hasChildren;
             public bool isExpanded;
+            public bool isParentExpanded;
             public TextHandler.TextStyle style;
             public HierarchyItemHandler.UiHierarchyItemActions actions;
             public Action<Vector3> rightClickAction;
+            public DropActions dropActions;
+            public DclEntity draggedEntity;
 
             public override bool Equals(Atom.Data other)
             {
@@ -28,9 +32,12 @@ namespace Assets.Scripts.Visuals.UiBuilder
                     level.Equals(otherHierarchyItem.level) &&
                     hasChildren.Equals(otherHierarchyItem.hasChildren) &&
                     isExpanded.Equals(otherHierarchyItem.isExpanded) &&
+                    isParentExpanded.Equals(otherHierarchyItem.isParentExpanded) &&
                     style.Equals(otherHierarchyItem.style) &&
                     actions.Equals(otherHierarchyItem.actions) &&
-                    rightClickAction.Equals(otherHierarchyItem.rightClickAction);
+                    rightClickAction.Equals(otherHierarchyItem.rightClickAction) &&
+                    dropActions.Equals(otherHierarchyItem.dropActions) &&
+                    draggedEntity.Equals(otherHierarchyItem.draggedEntity);
             }
         }
 
@@ -55,21 +62,7 @@ namespace Assets.Scripts.Visuals.UiBuilder
                 // Update data
                 var hierarchyItemHandler = gameObject.gameObject.GetComponent<HierarchyItemHandler>();
 
-                hierarchyItemHandler.text.text = newHierarchyItemData.name;
-                hierarchyItemHandler.indent.offsetMin = new Vector2(20 * newHierarchyItemData.level, 0);
-                hierarchyItemHandler.text.textStyle = newHierarchyItemData.style;
-                hierarchyItemHandler.actions = newHierarchyItemData.actions;
-                hierarchyItemHandler.rightClickHandler.onRightClick = newHierarchyItemData.rightClickAction;
-
-                if (newHierarchyItemData.hasChildren)
-                {
-                    hierarchyItemHandler.showArrow = true;
-                    hierarchyItemHandler.isExpanded = newHierarchyItemData.isExpanded;
-                }
-                else
-                {
-                    hierarchyItemHandler.showArrow = false;
-                }
+                hierarchyItemHandler.UpdateHandlers(newHierarchyItemData);
 
                 data = newHierarchyItemData;
             }
@@ -89,7 +82,10 @@ namespace Assets.Scripts.Visuals.UiBuilder
 
     public static class HierarchyItemPanelHelper
     {
-        public static HierarchyItemAtom.Data AddHierarchyItem(this PanelAtom.Data panelAtomData, string name, int level, bool hasChildren, bool isExpanded, TextHandler.TextStyle textStyle, HierarchyItemHandler.UiHierarchyItemActions actions, Action<Vector3> rightClickAction)
+        public static HierarchyItemAtom.Data AddHierarchyItem(this PanelAtom.Data panelAtomData, string name, int level,
+            bool hasChildren, bool isExpanded, bool isParentExpanded, TextHandler.TextStyle textStyle,
+            HierarchyItemHandler.UiHierarchyItemActions actions, Action<Vector3> rightClickAction,
+            Action<GameObject> dropActionUpper, Action<GameObject> dropActionMiddle, Action<GameObject> dropActionLower, DclEntity entity = null)
         {
             var data = new HierarchyItemAtom.Data
             {
@@ -97,13 +93,28 @@ namespace Assets.Scripts.Visuals.UiBuilder
                 level = level,
                 hasChildren = hasChildren,
                 isExpanded = isExpanded,
+                isParentExpanded = isParentExpanded,
                 style = textStyle,
                 actions = actions,
-                rightClickAction = rightClickAction
+                rightClickAction = rightClickAction,
+                dropActions =
+                {
+                    dropActionUpper = dropActionUpper,
+                    dropActionMiddle = dropActionMiddle,
+                    dropActionLower = dropActionLower,
+                },
+                draggedEntity = entity
             };
 
             panelAtomData.childDates.Add(data);
             return data;
         }
+    }
+
+    public struct DropActions
+    {
+        public Action<GameObject> dropActionUpper;
+        public Action<GameObject> dropActionMiddle;
+        public Action<GameObject> dropActionLower;
     }
 }

--- a/Assets/Scripts/Visuals/UiBuilder/SpacerAtom.cs
+++ b/Assets/Scripts/Visuals/UiBuilder/SpacerAtom.cs
@@ -12,6 +12,7 @@ namespace Assets.Scripts.Visuals.UiBuilder
         {
             public int height;
             [CanBeNull] public Action<Vector3> rightClickAction;
+            [CanBeNull] public Action<GameObject> dropAction;
 
             public override bool Equals(Atom.Data other)
             {
@@ -22,7 +23,8 @@ namespace Assets.Scripts.Visuals.UiBuilder
 
                 return
                     height.Equals(otherSpacer.height) &&
-                    rightClickAction == otherSpacer.rightClickAction;
+                    rightClickAction == otherSpacer.rightClickAction &&
+                    dropAction == otherSpacer.dropAction;
             }
         }
 
@@ -50,7 +52,14 @@ namespace Assets.Scripts.Visuals.UiBuilder
                 
                 le.minHeight = newSpacerData.height;
                 spacerHandler.rightClickHandler.onRightClick = newSpacerData.rightClickAction;
+                spacerHandler.dropHandler.onDrop = newSpacerData.dropAction;
+                spacerHandler.dropHandler.ResetHandler();
                 
+                if (newSpacerData.dropAction != null)
+                {
+                    spacerHandler.dropHandler.SetEnabled(true);
+                }
+
                 data = newSpacerData;
             }
         }
@@ -69,12 +78,13 @@ namespace Assets.Scripts.Visuals.UiBuilder
 
     public static class SpacerPanelHelper
     {
-        public static SpacerAtom.Data AddSpacer(this PanelAtom.Data panelAtomData, int height, Action<Vector3> rightClickAction = null)
+        public static SpacerAtom.Data AddSpacer(this PanelAtom.Data panelAtomData, int height, Action<Vector3> rightClickAction = null, Action<GameObject> dropAction = null)
         {
             var data = new SpacerAtom.Data
             {
                 height = height,
-                rightClickAction = rightClickAction
+                rightClickAction = rightClickAction,
+                dropAction = dropAction
             };
 
             panelAtomData.childDates.Add(data);

--- a/Assets/Scripts/Visuals/UiHandler/DragAndDropHandler.cs
+++ b/Assets/Scripts/Visuals/UiHandler/DragAndDropHandler.cs
@@ -1,0 +1,166 @@
+using System.Linq;
+using Assets.Scripts.Visuals.UiBuilder;
+using Assets.Scripts.Visuals.UiHandler;
+using TMPro;
+
+namespace Visuals.UiHandler
+{
+    using Assets.Scripts.SceneState;
+    using UnityEngine;
+    using UnityEngine.EventSystems;
+    using UnityEngine.UI;
+
+    public class DragAndDropHandler : MonoBehaviour, IDragHandler, IBeginDragHandler, IEndDragHandler,
+        IPointerEnterHandler, IPointerExitHandler
+    {
+        public TextMeshProUGUI clickableText;
+        public TextHandler clickableTextHandler;
+        public DclEntity draggedEntity = null;
+        public DropHandler dropHandlerUpper;
+        public DropHandler dropHandlerCenter;
+        public DropHandler dropHandlerLower;
+        public RightClickHandler rightClickHandler;
+        
+        private VerticalLayoutGroup verticalLayoutGroupParent;
+        private bool isBeingDragged = false;
+        private bool init = false;
+        private TextHandler.TextStyle previousTextStyle;
+        public bool isExpanded = false;
+        public bool isParentExpanded = false;
+
+
+        private void Start()
+        {
+            init = true;
+            verticalLayoutGroupParent = transform.parent.gameObject.GetComponent<VerticalLayoutGroup>();
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            previousTextStyle = clickableTextHandler.textStyle;
+            clickableTextHandler.textStyle = TextHandler.TextStyle.Disabled;
+            SetDragHandlerEnabled(false);
+            rightClickHandler.enabled = false;
+
+
+            isBeingDragged = true;
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            clickableTextHandler.textStyle = previousTextStyle;
+            verticalLayoutGroupParent.enabled = false;
+
+            SetDragHandlerEnabled(true);
+            rightClickHandler.enabled = true;
+
+            verticalLayoutGroupParent.enabled = true;
+
+            isBeingDragged = false;
+        }
+
+
+        //Called for all Handlers that aren't dragged
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            if (!isBeingDragged && eventData.pointerDrag != null)
+            {
+                SetDragHandlerEnabled(false);
+                rightClickHandler.enabled = false;
+                SetDropHandlersEnabled(true);
+                UpdateDropHandlerLowerHoverImage();
+                UpdateDropHandlerUpperHoverImage();
+            }
+        }
+
+        //Called for all Handlers that aren't dragged
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            if (!isBeingDragged && eventData.pointerDrag != null)
+            {
+                SetDragHandlerEnabled(true);
+                rightClickHandler.enabled = true;
+                SetDropHandlersEnabled(false);
+            }
+        }
+
+        private void SetDropHandlersEnabled(bool enabled)
+        {
+            dropHandlerUpper.SetEnabled(enabled);
+            dropHandlerCenter.SetEnabled(enabled);
+            dropHandlerLower.SetEnabled(enabled);
+        }
+
+        /// <summary>
+        /// Updates the lower drop handlers current hover image
+        /// </summary>
+        private void UpdateDropHandlerLowerHoverImage()
+        {
+            if (isExpanded)
+            {
+                dropHandlerLower.SetCurrentHoverImageSpecial();
+            }
+            else
+            {
+                dropHandlerLower.SetCurrentHoverImageDefault();
+            }
+        }
+        
+        /// <summary>
+        /// Updates the upper drop handlers current hover image
+        /// </summary>
+        private void UpdateDropHandlerUpperHoverImage()
+        {
+            var parent = draggedEntity?.Parent;
+
+            if (parent == null)
+            {
+                dropHandlerUpper.SetCurrentHoverImageDefault();
+                return;
+            }
+
+            var firstChild = parent.Children.OrderBy(e => e.hierarchyOrder).First();
+            
+            if (firstChild.Id.Equals(draggedEntity.Id))
+            {
+                if (isParentExpanded)
+                {
+                    dropHandlerUpper.SetCurrentHoverImageSpecial();
+                    return;
+                }
+            }
+            
+            dropHandlerUpper.SetCurrentHoverImageDefault();
+        }
+
+        private void SetDragHandlerEnabled(bool enabled)
+        {
+            clickableText.raycastTarget = enabled;
+        }
+
+        public void ResetHandler()
+        {
+            if (init)
+            {
+                SetDropHandlersEnabled(false);
+                SetDragHandlerEnabled(true);
+
+                rightClickHandler.enabled = true;
+
+                dropHandlerUpper.ResetHandler();
+                dropHandlerCenter.ResetHandler();
+                dropHandlerLower.ResetHandler();
+            }
+        }
+
+        public void UpdateDropHandlers(DropActions dropActions)
+        {
+            dropHandlerUpper.onDrop = dropActions.dropActionUpper;
+            dropHandlerCenter.onDrop = dropActions.dropActionMiddle;
+            dropHandlerLower.onDrop = dropActions.dropActionLower;
+        }
+        
+        //Don't remove!
+        public void OnDrag(PointerEventData eventData) { }
+    }
+}

--- a/Assets/Scripts/Visuals/UiHandler/DragAndDropHandler.cs
+++ b/Assets/Scripts/Visuals/UiHandler/DragAndDropHandler.cs
@@ -28,6 +28,8 @@ namespace Visuals.UiHandler
         public bool isExpanded = false;
         public bool isParentExpanded = false;
 
+        private static bool isAnyDragged = false; // Quick and dirty fix TODO: Change it
+
 
         private void Start()
         {
@@ -44,6 +46,7 @@ namespace Visuals.UiHandler
 
 
             isBeingDragged = true;
+            isAnyDragged = true;
         }
 
         public void OnEndDrag(PointerEventData eventData)
@@ -57,13 +60,14 @@ namespace Visuals.UiHandler
             verticalLayoutGroupParent.enabled = true;
 
             isBeingDragged = false;
+            isAnyDragged = false;
         }
 
 
         //Called for all Handlers that aren't dragged
         public void OnPointerEnter(PointerEventData eventData)
         {
-            if (!isBeingDragged && eventData.pointerDrag != null)
+            if (!isBeingDragged && eventData.pointerDrag != null && isAnyDragged)
             {
                 SetDragHandlerEnabled(false);
                 rightClickHandler.enabled = false;

--- a/Assets/Scripts/Visuals/UiHandler/DragAndDropHandler.cs.meta
+++ b/Assets/Scripts/Visuals/UiHandler/DragAndDropHandler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 202167157a2b4386a8b5c42a03c40148
+timeCreated: 1674772641

--- a/Assets/Scripts/Visuals/UiHandler/DropHandler.cs
+++ b/Assets/Scripts/Visuals/UiHandler/DropHandler.cs
@@ -1,0 +1,100 @@
+namespace Visuals.UiHandler
+{
+    using System;
+    using UnityEngine;
+    using UnityEngine.EventSystems;
+    using UnityEngine.UI;
+
+    public class DropHandler : MonoBehaviour, IDropHandler, IPointerEnterHandler, IPointerExitHandler
+    {
+        public Action<GameObject> onDrop;
+        public Image clickableImage;
+        public Image hoverImageDefault;
+        public Image hoverImageSpecial;
+        private Image currentHoverImage;
+        [HideInInspector]
+        public bool rayCastTarget = false;
+        private bool init = false;
+
+        private void Start()
+        {
+            currentHoverImage = hoverImageDefault;
+            init = true;
+        }
+
+        public void OnDrop(PointerEventData eventData)
+        {
+            var draggedGameObject = eventData.pointerDrag;
+
+            if (!rayCastTarget || draggedGameObject == null || !CheckIsDraggable(eventData))
+            {
+                return;
+            }
+
+            onDrop?.Invoke(draggedGameObject);
+        }
+
+        //TODO make more efficient by preventing all scroll rects from being draggable
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            if (!rayCastTarget || eventData.pointerDrag == null || !CheckIsDraggable(eventData))
+            {
+                return;
+            };
+            
+            ChangeImageAlpha(0.1f);
+        }
+
+        //TODO make more efficient by preventing all scroll rects from being draggable
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            if (!rayCastTarget || eventData.pointerDrag == null ||!CheckIsDraggable(eventData))
+            {
+                return;
+            }
+
+            ChangeImageAlpha(0);
+        }
+
+        private void ChangeImageAlpha(float alpha)
+        {
+            var value = Mathf.Clamp(alpha, 0, 1);
+
+            var imageColor = currentHoverImage.color;
+            imageColor.a = value;
+            currentHoverImage.color = imageColor;
+        }
+        
+        public void SetEnabled(bool enabled)
+        {
+            clickableImage.raycastTarget = enabled;
+            this.rayCastTarget = enabled;
+        }
+
+        public void ResetHandler()
+        {
+            if (!init)
+            {
+                return;
+            }
+            
+            SetEnabled(false);
+            ChangeImageAlpha(0);
+        }
+
+        private static bool CheckIsDraggable(PointerEventData eventData)
+        {
+            return eventData.pointerDrag.TryGetComponent(out DragAndDropHandler dragAndDropHandler);
+        }
+
+        public void SetCurrentHoverImageDefault()
+        {
+            currentHoverImage = hoverImageDefault;
+        }
+        
+        public void SetCurrentHoverImageSpecial()
+        {
+            currentHoverImage = hoverImageSpecial;
+        }
+    }
+}

--- a/Assets/Scripts/Visuals/UiHandler/DropHandler.cs.meta
+++ b/Assets/Scripts/Visuals/UiHandler/DropHandler.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dd1af13020f046e2affc4a6908972dac
+timeCreated: 1674772686

--- a/Assets/Scripts/Visuals/UiHandler/HierarchyItemHandler.cs
+++ b/Assets/Scripts/Visuals/UiHandler/HierarchyItemHandler.cs
@@ -1,7 +1,9 @@
 using System;
+using Assets.Scripts.Visuals.UiBuilder;
 using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.UI;
+using Visuals.UiHandler;
 
 namespace Assets.Scripts.Visuals.UiHandler
 {
@@ -21,6 +23,9 @@ namespace Assets.Scripts.Visuals.UiHandler
 
         [SerializeField]
         public RightClickHandler rightClickHandler;
+        
+        [SerializeField]
+        public DragAndDropHandler dragAndDropHandler;
 
         public struct UiHierarchyItemActions
         {
@@ -64,5 +69,34 @@ namespace Assets.Scripts.Visuals.UiHandler
         {
             set => arrowContainer.gameObject.SetActive(value);
         }
+
+        public void UpdateHandlers(HierarchyItemAtom.Data newHierarchyItemData)
+        {
+            actions = newHierarchyItemData.actions;
+            rightClickHandler.onRightClick = newHierarchyItemData.rightClickAction;
+            dragAndDropHandler.UpdateDropHandlers(newHierarchyItemData.dropActions);
+            dragAndDropHandler.draggedEntity = newHierarchyItemData.draggedEntity;
+            dragAndDropHandler.isExpanded = newHierarchyItemData.isExpanded;
+            dragAndDropHandler.isParentExpanded = newHierarchyItemData.isParentExpanded;
+            
+            text.text = newHierarchyItemData.name;
+            text.textStyle = newHierarchyItemData.style;
+            text.TextComponent.enabled = true;
+            
+            indent.offsetMin = new Vector2(20 * newHierarchyItemData.level, 0);
+
+            if (newHierarchyItemData.hasChildren)
+            {
+                showArrow = true;
+                isExpanded = newHierarchyItemData.isExpanded;
+            }
+            else
+            {
+                showArrow = false;
+            }
+            
+            dragAndDropHandler.ResetHandler();
+        }
+        
     }
 }

--- a/Assets/Scripts/Visuals/UiHandler/SpacerHandler.cs
+++ b/Assets/Scripts/Visuals/UiHandler/SpacerHandler.cs
@@ -7,5 +7,8 @@ namespace Visuals.UiHandler
     {
         [SerializeField]
         public RightClickHandler rightClickHandler;
+        
+        [SerializeField]
+        public DropHandler dropHandler;
     }
 }

--- a/Assets/Scripts/Visuals/UiHandler/TextHandler.cs
+++ b/Assets/Scripts/Visuals/UiHandler/TextHandler.cs
@@ -11,6 +11,7 @@ namespace Assets.Scripts.Visuals.UiHandler
             Normal,
             PrimarySelection,
             SecondarySelection,
+            Disabled
         }
 
         [SerializeField]
@@ -21,6 +22,9 @@ namespace Assets.Scripts.Visuals.UiHandler
 
         [SerializeField]
         public TMP_ColorGradient SecondaryColorGradient;
+        
+        [SerializeField]
+        public TMP_ColorGradient DisabledColorGradient;
 
         [Header("Scene References")]
         [SerializeField]
@@ -34,11 +38,37 @@ namespace Assets.Scripts.Visuals.UiHandler
 
         public TextStyle textStyle
         {
+            get
+            {
+                if (TextComponent.colorGradientPreset == NormalColorGradient)
+                {
+                    return TextStyle.Normal;
+                }
+                
+                if (TextComponent.colorGradientPreset == PrimaryColorGradient)
+                {
+                    return TextStyle.PrimarySelection;
+                }
+
+                if (TextComponent.colorGradientPreset == SecondaryColorGradient)
+                {
+                    return TextStyle.SecondarySelection;
+                }
+
+                if (TextComponent.colorGradientPreset == DisabledColorGradient)
+                {
+                    return TextStyle.Disabled;
+                }
+
+                throw new ArgumentOutOfRangeException();
+            }
+
             set => TextComponent.colorGradientPreset = value switch
             {
                 TextStyle.Normal => NormalColorGradient,
                 TextStyle.PrimarySelection => PrimaryColorGradient,
                 TextStyle.SecondarySelection => SecondaryColorGradient,
+                TextStyle.Disabled => DisabledColorGradient,
                 _ => throw new ArgumentOutOfRangeException(nameof(value), value, null)
             };
         }

--- a/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
+++ b/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
@@ -8,6 +8,7 @@ using JetBrains.Annotations;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.Assertions;
 using Visuals.UiHandler;
 using Zenject;
 using static Assets.Scripts.Visuals.UiBuilder.UiBuilder;
@@ -158,6 +159,8 @@ namespace Assets.Scripts.Visuals
 
             foreach (var entity in dclEntities)
             {
+                Assert.IsNotNull(entity);
+                
                 var isPrimarySelection = scene.SelectionState.PrimarySelectedEntity == entity;
 
                 var isSecondarySelection = scene.SelectionState.SecondarySelectedEntities.Contains(entity);
@@ -205,6 +208,7 @@ namespace Assets.Scripts.Visuals
                     {
                         var draggedEntity = draggedGameObject.GetComponent<DragAndDropHandler>().draggedEntity;
                         var aboveEntity = hierarchyOrderSystem.GetAboveSibling(entity);
+                        
                         hierarchyOrderSystem.DropUpper(draggedEntity, entity, aboveEntity);
                     },
                     draggedGameObject =>

--- a/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
+++ b/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
@@ -112,7 +112,7 @@ namespace Assets.Scripts.Visuals
         {
             var mainPanelData = NewPanelData();
 
-            var scene = sceneManagerSystem.GetCurrentScene();
+            var scene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             if (scene == null)
             {

--- a/Assets/Scripts/Visuals/UiInspectorVisuals.cs
+++ b/Assets/Scripts/Visuals/UiInspectorVisuals.cs
@@ -91,7 +91,7 @@ namespace Assets.Scripts.Visuals
 
             var inspectorPanel = new PanelAtom.Data();
 
-            var currentScene = sceneManagerSystem.GetCurrentScene();
+            var currentScene = sceneManagerSystem.GetCurrentSceneOrNull();
 
             if (currentScene == null)
             {


### PR DESCRIPTION
**Summary**
The hierarchy order determines the position of an entity in the hierarchy and doesn't change unless the entity is moved.
- The hierarchy order of each entity is saved in its respective file. 
- Scrolling of the hierarchy is done using the mouse wheel.

**TODO (in another PR)**
- The global rotation, scale and translate is only kept on parenting if the scale is uniform. (Sounds complicated)
- Hovering over object extends the hierarchy