### PR TITLE
Ref/feature/comma as decimal point

### DIFF
--- a/Assets/Scripts/System/NumberInputSystem.cs
+++ b/Assets/Scripts/System/NumberInputSystem.cs
@@ -8,12 +8,36 @@ namespace Assets.Scripts.System
         public float? ValidateNumberInput(string value)
         {
             value = value.Replace(',', '.');
+            value = RemoveExcessDecimalSeparators(value);
             if (float.TryParse(value, Filter, CultureInfo.InvariantCulture, out var result))
             {
                 return result;
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Checks if there is more than one decimal separator (dot) and removes the excess ones.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        string RemoveExcessDecimalSeparators(string value)
+        {
+            int decimalPointCount = 0;
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (value[i] == '.')
+                {
+                    decimalPointCount++;
+                    if (decimalPointCount > 1)
+                    {
+                        value = value.Remove(i, 1);
+                    }
+                }
+            }
+
+            return value;
         }
     }
 }

--- a/Assets/Scripts/System/NumberInputSystem.cs
+++ b/Assets/Scripts/System/NumberInputSystem.cs
@@ -7,6 +7,7 @@ namespace Assets.Scripts.System
         private const NumberStyles Filter = NumberStyles.Integer | NumberStyles.AllowDecimalPoint;
         public float? ValidateNumberInput(string value)
         {
+            value = value.Replace(',', '.');
             if (float.TryParse(value, Filter, CultureInfo.InvariantCulture, out var result))
             {
                 return result;


### PR DESCRIPTION
Task: #863g2p6xw

Commas get replaced by dots to make them into a valid separator char for a decimal number. Also if there is more than one decimal separator, the excess ones get removed so that the user doesn't have to delete them manually.