### PR TITLE
Added MenuItem Change Dev Project Path

### DIFF
--- a/Assets/Scripts/EditorState/PathState.cs
+++ b/Assets/Scripts/EditorState/PathState.cs
@@ -26,12 +26,6 @@ namespace Assets.Scripts.EditorState
                     _projectPath = File.ReadAllText(devProjectPathFilePath);
                 }
 
-                if (!File.Exists(_projectPath + "/scene.json"))
-                {
-                    _projectPath = EditorUtility.OpenFolderPanel("Select DCL project folder", "", "");
-                    File.WriteAllText(devProjectPathFilePath, _projectPath);
-                }
-
 #else
                 _projectPath = Path.GetFullPath(".");
 #endif

--- a/Assets/Scripts/Utility/StaticUtilities.cs
+++ b/Assets/Scripts/Utility/StaticUtilities.cs
@@ -3,8 +3,10 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using UnityEditor;
 using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace Assets.Scripts.Utility
 {
@@ -72,6 +74,34 @@ namespace Assets.Scripts.Utility
         public static void UnlockAssemblies()
         {
             EditorApplication.UnlockReloadAssemblies();
+        }
+
+        [MenuItem("Edit/Change Dev Project Path")]
+        public static void ChangeDevProjectPath()
+        {
+            var devProjectPathFilePath = Application.dataPath + "/dev_project_path.txt";
+            string oldPath = null;
+
+            if (File.Exists(devProjectPathFilePath))
+            {
+                oldPath = File.ReadAllText(devProjectPathFilePath);
+            }
+
+            var newPath = EditorUtility.OpenFolderPanel("Select Dev Project Path", oldPath ?? Application.dataPath, "Project Folder");
+
+            if (newPath == "")
+            {
+                Debug.Log("Path selection aborted by user");
+                return;
+            }
+
+            if (!File.Exists(newPath + "/scene.json"))
+            {
+                // display a warning, but still allow it, so the developer is able to test invalid project paths
+                Debug.LogWarning($"The path \"{newPath}\" does not seem to be a dcl project");
+            }
+
+            File.WriteAllText(devProjectPathFilePath, newPath);
         }
 #endif // UNITY_EDITOR
 


### PR DESCRIPTION
#861me3mdh

You don't need to delete the dev_project_path.txt file every time you want to change your test path. Instead, there is a menu item for that now.