### PR TITLE
Ref/bug/input trigger behaviour

### DIFF
--- a/Assets/Scripts/Interaction/GeneralInputInteraction.cs
+++ b/Assets/Scripts/Interaction/GeneralInputInteraction.cs
@@ -453,7 +453,15 @@ namespace Assets.Scripts.Interaction
 
         private void UpdateHoldingGizmoTool()
         {
-            //// When releasing LMB, stop holding gizmo
+            // Cancel the current gizmo operation
+            if (inputSystemAsset.Hotkeys.Cancel.triggered) 
+            {
+                inputState.InState = InputState.InStateType.NoInput;
+                gizmoToolSystem.CancelHolding();
+                return;
+            }
+
+            // When releasing LMB, stop holding gizmo
             if (!inputHelper.IsLeftMouseButtonPressed())
             {
                 inputState.InState = InputState.InStateType.NoInput;

--- a/Assets/Scripts/System/GizmoToolSystem.cs
+++ b/Assets/Scripts/System/GizmoToolSystem.cs
@@ -441,6 +441,25 @@ namespace Assets.Scripts.System
             }
         }
 
+        public void CancelHolding()
+        {
+            switch (gizmoToolMode)
+            {
+                case ToolMode.Translate:
+                    gizmoState.affectedTransform.globalPosition = gizmoState.affectedTransform.globalFixedPosition;
+                    break;
+                case ToolMode.Rotate:
+                    gizmoState.affectedTransform.globalRotation = gizmoState.affectedTransform.globalFixedRotation;
+                    break;
+                case ToolMode.Scale:
+                    gizmoState.affectedTransform.scale.SetFloatingValue(gizmoState.affectedTransform.scale.FixedValue);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            editorEvents.InvokeSelectionChangedEvent();
+        }
 
         private void ExecuteTranslateCommand()
         {

--- a/Assets/Scripts/System/InputSystem/InputSystemAsset.cs
+++ b/Assets/Scripts/System/InputSystem/InputSystemAsset.cs
@@ -308,7 +308,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""8426de5b-6dfe-4cf4-a9f4-bb9d6e4bf68a"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 },
                 {
                     ""name"": ""Translate"",
@@ -316,7 +316,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""ae1e3c65-3c80-4b5d-ae3a-fce036399c9c"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 },
                 {
                     ""name"": ""Rotate"",
@@ -324,7 +324,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""2513e2b5-bea4-466b-8c6c-7d406d9a27c2"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 },
                 {
                     ""name"": ""Scale"",
@@ -332,7 +332,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""2dea60ed-d46e-4c2c-96fb-7b684bf4c9a8"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 },
                 {
                     ""name"": ""Duplicate"",
@@ -340,7 +340,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""a89fc159-e2c8-43e8-835b-b3abe72d9a23"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 },
                 {
                     ""name"": ""Delete"",
@@ -348,7 +348,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""57999a8f-1f67-41a8-95ca-23f8ae77af75"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 },
                 {
                     ""name"": ""Cancel"",
@@ -356,7 +356,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""id"": ""63e5cb43-05ec-4a36-a575-5bc290cc4dc3"",
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
-                    ""interactions"": ""Press(behavior=1)""
+                    ""interactions"": """"
                 }
             ],
             ""bindings"": [

--- a/Assets/Scripts/System/InputSystem/InputSystemAsset.cs
+++ b/Assets/Scripts/System/InputSystem/InputSystemAsset.cs
@@ -349,6 +349,14 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""expectedControlType"": ""Button"",
                     ""processors"": """",
                     ""interactions"": ""Press(behavior=1)""
+                },
+                {
+                    ""name"": ""Cancel"",
+                    ""type"": ""Button"",
+                    ""id"": ""63e5cb43-05ec-4a36-a575-5bc290cc4dc3"",
+                    ""expectedControlType"": ""Button"",
+                    ""processors"": """",
+                    ""interactions"": ""Press(behavior=1)""
                 }
             ],
             ""bindings"": [
@@ -527,6 +535,17 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                     ""action"": ""Delete"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
+                },
+                {
+                    ""name"": """",
+                    ""id"": ""507890a0-c6fc-496c-b7e0-6ce7346f8064"",
+                    ""path"": ""<Keyboard>/escape"",
+                    ""interactions"": """",
+                    ""processors"": """",
+                    ""groups"": """",
+                    ""action"": ""Cancel"",
+                    ""isComposite"": false,
+                    ""isPartOfComposite"": false
                 }
             ]
         },
@@ -615,6 +634,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
         m_Hotkeys_Scale = m_Hotkeys.FindAction("Scale", throwIfNotFound: true);
         m_Hotkeys_Duplicate = m_Hotkeys.FindAction("Duplicate", throwIfNotFound: true);
         m_Hotkeys_Delete = m_Hotkeys.FindAction("Delete", throwIfNotFound: true);
+        m_Hotkeys_Cancel = m_Hotkeys.FindAction("Cancel", throwIfNotFound: true);
         // Modifier
         m_Modifier = asset.FindActionMap("Modifier", throwIfNotFound: true);
         m_Modifier_Shift = m_Modifier.FindAction("Shift", throwIfNotFound: true);
@@ -742,6 +762,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
     private readonly InputAction m_Hotkeys_Scale;
     private readonly InputAction m_Hotkeys_Duplicate;
     private readonly InputAction m_Hotkeys_Delete;
+    private readonly InputAction m_Hotkeys_Cancel;
     public struct HotkeysActions
     {
         private @InputSystemAsset m_Wrapper;
@@ -754,6 +775,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
         public InputAction @Scale => m_Wrapper.m_Hotkeys_Scale;
         public InputAction @Duplicate => m_Wrapper.m_Hotkeys_Duplicate;
         public InputAction @Delete => m_Wrapper.m_Hotkeys_Delete;
+        public InputAction @Cancel => m_Wrapper.m_Hotkeys_Cancel;
         public InputActionMap Get() { return m_Wrapper.m_Hotkeys; }
         public void Enable() { Get().Enable(); }
         public void Disable() { Get().Disable(); }
@@ -787,6 +809,9 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                 @Delete.started -= m_Wrapper.m_HotkeysActionsCallbackInterface.OnDelete;
                 @Delete.performed -= m_Wrapper.m_HotkeysActionsCallbackInterface.OnDelete;
                 @Delete.canceled -= m_Wrapper.m_HotkeysActionsCallbackInterface.OnDelete;
+                @Cancel.started -= m_Wrapper.m_HotkeysActionsCallbackInterface.OnCancel;
+                @Cancel.performed -= m_Wrapper.m_HotkeysActionsCallbackInterface.OnCancel;
+                @Cancel.canceled -= m_Wrapper.m_HotkeysActionsCallbackInterface.OnCancel;
             }
             m_Wrapper.m_HotkeysActionsCallbackInterface = instance;
             if (instance != null)
@@ -815,6 +840,9 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
                 @Delete.started += instance.OnDelete;
                 @Delete.performed += instance.OnDelete;
                 @Delete.canceled += instance.OnDelete;
+                @Cancel.started += instance.OnCancel;
+                @Cancel.performed += instance.OnCancel;
+                @Cancel.canceled += instance.OnCancel;
             }
         }
     }
@@ -886,6 +914,7 @@ public class @InputSystemAsset : IInputActionCollection, IDisposable
         void OnScale(InputAction.CallbackContext context);
         void OnDuplicate(InputAction.CallbackContext context);
         void OnDelete(InputAction.CallbackContext context);
+        void OnCancel(InputAction.CallbackContext context);
     }
     public interface IModifierActions
     {

--- a/Assets/Scripts/System/InputSystem/InputSystemAsset.inputactions
+++ b/Assets/Scripts/System/InputSystem/InputSystemAsset.inputactions
@@ -336,6 +336,14 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "Press(behavior=1)"
+                },
+                {
+                    "name": "Cancel",
+                    "type": "Button",
+                    "id": "63e5cb43-05ec-4a36-a575-5bc290cc4dc3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press(behavior=1)"
                 }
             ],
             "bindings": [
@@ -512,6 +520,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "Delete",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "507890a0-c6fc-496c-b7e0-6ce7346f8064",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Cancel",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/System/InputSystem/InputSystemAsset.inputactions
+++ b/Assets/Scripts/System/InputSystem/InputSystemAsset.inputactions
@@ -295,7 +295,7 @@
                     "id": "8426de5b-6dfe-4cf4-a9f4-bb9d6e4bf68a",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 },
                 {
                     "name": "Translate",
@@ -303,7 +303,7 @@
                     "id": "ae1e3c65-3c80-4b5d-ae3a-fce036399c9c",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 },
                 {
                     "name": "Rotate",
@@ -311,7 +311,7 @@
                     "id": "2513e2b5-bea4-466b-8c6c-7d406d9a27c2",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 },
                 {
                     "name": "Scale",
@@ -319,7 +319,7 @@
                     "id": "2dea60ed-d46e-4c2c-96fb-7b684bf4c9a8",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 },
                 {
                     "name": "Duplicate",
@@ -327,7 +327,7 @@
                     "id": "a89fc159-e2c8-43e8-835b-b3abe72d9a23",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 },
                 {
                     "name": "Delete",
@@ -335,7 +335,7 @@
                     "id": "57999a8f-1f67-41a8-95ca-23f8ae77af75",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 },
                 {
                     "name": "Cancel",
@@ -343,7 +343,7 @@
                     "id": "63e5cb43-05ec-4a36-a575-5bc290cc4dc3",
                     "expectedControlType": "Button",
                     "processors": "",
-                    "interactions": "Press(behavior=1)"
+                    "interactions": ""
                 }
             ],
             "bindings": [


### PR DESCRIPTION
Must be merged after #149 Ref/feature/gizmo cancel

Remove the press interactions on all hotkey settings in the input system. They have changed the trigger from `press only` to `release only`.

#861me9jzt