### PR TITLE
Ref/feature/hierarchy no dragndrop options

### DIFF
--- a/Assets/Scripts/System/HierarchyOrderSystem.cs
+++ b/Assets/Scripts/System/HierarchyOrderSystem.cs
@@ -349,5 +349,51 @@ namespace Assets.Scripts.System
 
             ChangeHierarchyOrderAsCommand(draggedEntity, null, newHierarchyOrder, null);
         }
+
+        public void PlaceAbove([NotNull]DclEntity hoveredEntity)
+        {
+            var scene = sceneManagerSystem.GetCurrentScene();
+            var selectedEntity = scene.SelectionState.PrimarySelectedEntity;
+            
+            if (selectedEntity == null || selectedEntity.Id == hoveredEntity.Id)
+            {
+                return;
+            }
+            
+            DropUpper(selectedEntity, hoveredEntity, GetAboveSibling(hoveredEntity));
+        }
+
+        public void PlaceBelow([NotNull]DclEntity hoveredEntity)
+        {
+            var scene = sceneManagerSystem.GetCurrentScene();
+            var selectedEntity = scene.SelectionState.PrimarySelectedEntity;
+            
+            if (selectedEntity == null || selectedEntity.Id == hoveredEntity.Id)
+            {
+                return;
+            }
+            
+            DropLower(selectedEntity, hoveredEntity, GetBelowSibling(hoveredEntity), null, false);
+        }
+
+        public void PlaceAsChild([NotNull] DclEntity hoveredEntity)
+        {
+            var scene = sceneManagerSystem.GetCurrentScene();
+            var selectedEntity = scene.SelectionState.PrimarySelectedEntity;
+            
+            if (selectedEntity == null || selectedEntity.Id == hoveredEntity.Id)
+            {
+                return;
+            }
+
+            if (hierarchyExpansionState.IsExpanded(hoveredEntity.Id))
+            {
+                DropLower(selectedEntity, hoveredEntity, null, hoveredEntity.Children.OrderBy(e => e.hierarchyOrder).FirstOrDefault(), true);
+            }
+            else
+            {
+                DropMiddle(selectedEntity, hoveredEntity);
+            }
+        }
     }
 }

--- a/Assets/Scripts/Visuals/UiBuilder/ContextSubmenuAtom.cs
+++ b/Assets/Scripts/Visuals/UiBuilder/ContextSubmenuAtom.cs
@@ -4,6 +4,7 @@ using Assets.Scripts.EditorState;
 using Assets.Scripts.System;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace Assets.Scripts.Visuals.UiBuilder
 {
@@ -17,6 +18,7 @@ namespace Assets.Scripts.Visuals.UiBuilder
             public List<ContextMenuItem> submenuItems;
             public float menuWidth;
             public ContextMenuSystem contextMenuSystem;
+            public bool isDisabled { get; set; }
 
             public override bool Equals(Atom.Data other)
             {
@@ -31,7 +33,8 @@ namespace Assets.Scripts.Visuals.UiBuilder
                     title.Equals(otherContextMenuText.title) &&
                     submenuItems.Equals(otherContextMenuText.submenuItems) &&
                     menuWidth.Equals(otherContextMenuText.menuWidth) &&
-                    contextMenuSystem.Equals(otherContextMenuText.contextMenuSystem);
+                    contextMenuSystem.Equals(otherContextMenuText.contextMenuSystem) &&
+                    isDisabled.Equals(otherContextMenuText.isDisabled);
             }
         }
 
@@ -58,6 +61,12 @@ namespace Assets.Scripts.Visuals.UiBuilder
 
                 var text = gameObject.gameObject.GetComponentInChildren<TextMeshProUGUI>();
                 text.text = newContextMenuTextData.title;
+                
+                if (newContextMenuTextData.isDisabled)
+                {
+                    var button = gameObject.gameObject.GetComponent<Button>();
+                    button.interactable = false;
+                }
 
                 var hoverHandler = gameObject.gameObject.GetComponent<ContextMenuHoverHandler>();
                 hoverHandler.OnHoverAction = () =>
@@ -94,7 +103,9 @@ namespace Assets.Scripts.Visuals.UiBuilder
 
     public static class ContextSubmenuPanelHelper
     {
-        public static ContextSubmenuAtom.Data AddContextSubmenu(this PanelAtom.Data panelAtomData, Guid menuId, Guid submenuId, string title, List<ContextMenuItem> submenuItems, float menuWidth, ContextMenuSystem contextMenuSystem)
+        public static ContextSubmenuAtom.Data AddContextSubmenu(this PanelAtom.Data panelAtomData, Guid menuId,
+            Guid submenuId, string title, List<ContextMenuItem> submenuItems, float menuWidth,
+            ContextMenuSystem contextMenuSystem, bool isDisabled)
         {
             var data = new ContextSubmenuAtom.Data
             {
@@ -103,7 +114,8 @@ namespace Assets.Scripts.Visuals.UiBuilder
                 title = title,
                 submenuItems = submenuItems,
                 menuWidth = menuWidth,
-                contextMenuSystem = contextMenuSystem
+                contextMenuSystem = contextMenuSystem,
+                isDisabled = isDisabled
             };
 
             panelAtomData.childDates.Add(data);

--- a/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
+++ b/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
@@ -231,7 +231,13 @@ namespace Assets.Scripts.Visuals
                                     commandSystem.CommandFactory.CreateDuplicateEntity(entity.Id, newHierarchyOrderForDuplicatedEntity))),
                             new ContextMenuTextItem("Delete",
                                 () => commandSystem.ExecuteCommand(
-                                    commandSystem.CommandFactory.CreateRemoveEntity(entity)))
+                                    commandSystem.CommandFactory.CreateRemoveEntity(entity))),
+                            new ContextMenuTextItem("Place above", 
+                                () => hierarchyOrderSystem.PlaceAbove(entity)),
+                            new ContextMenuTextItem("Place below", 
+                            () => hierarchyOrderSystem.PlaceBelow(entity)),
+                            new ContextMenuTextItem("Place as Child", 
+                                () => hierarchyOrderSystem.PlaceAsChild(entity))
                         });
                     },
                     draggedGameObject =>

--- a/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
+++ b/Assets/Scripts/Visuals/UiHierarchyVisuals.cs
@@ -3,7 +3,6 @@ using Assets.Scripts.Events;
 using Assets.Scripts.SceneState;
 using Assets.Scripts.System;
 using Assets.Scripts.Visuals.UiBuilder;
-using Assets.Scripts.Utility;
 using Assets.Scripts.Visuals.UiHandler;
 using JetBrains.Annotations;
 using System.Collections.Generic;
@@ -13,7 +12,6 @@ using UnityEngine.UI;
 using UnityEngine.Assertions;
 using Visuals.UiHandler;
 using Zenject;
-using Zenject.SpaceFighter;
 using static Assets.Scripts.Visuals.UiBuilder.UiBuilder;
 
 namespace Assets.Scripts.Visuals
@@ -66,7 +64,6 @@ namespace Assets.Scripts.Visuals
         private SceneManagerSystem sceneManagerSystem;
         private CommandSystem commandSystem;
         private HierarchyOrderSystem hierarchyOrderSystem;
-        private AddEntitySystem addEntitySystem;
 
         [Inject]
         private void Construct(
@@ -77,8 +74,7 @@ namespace Assets.Scripts.Visuals
             SceneManagerSystem sceneManagerSystem,
             CommandSystem commandSystem,
             HierarchyContextMenuSystem hierarchyContextMenuSystem,
-            HierarchyOrderSystem hierarchyOrderSystem,
-            AddEntitySystem addEntitySystem)
+            HierarchyOrderSystem hierarchyOrderSystem)
         {
             this.events = events;
             this.uiBuilder = uiBuilderFactory.Create(content);
@@ -88,8 +84,6 @@ namespace Assets.Scripts.Visuals
             this.commandSystem = commandSystem;
             this.hierarchyContextMenuSystem = hierarchyContextMenuSystem;
             this.hierarchyOrderSystem = hierarchyOrderSystem;
-            this.addEntitySystem = addEntitySystem;
-
 
             SetupRightClickHandler();
             SetupEventListeners();
@@ -182,9 +176,10 @@ namespace Assets.Scripts.Visuals
             {
                 Assert.IsNotNull(entity);
 
-                var isPrimarySelection = scene.SelectionState.PrimarySelectedEntity == entity;
+                var selectionState = scene.SelectionState;
+                var isPrimarySelection = selectionState.PrimarySelectedEntity == entity;
 
-                var isSecondarySelection = scene.SelectionState.SecondarySelectedEntities.Contains(entity);
+                var isSecondarySelection = selectionState.SecondarySelectedEntities.Contains(entity);
 
                 var style =
                     isPrimarySelection ? TextHandler.TextStyle.PrimarySelection :
@@ -198,6 +193,7 @@ namespace Assets.Scripts.Visuals
 
                 var isExpanded = hierarchyChangeSystem.IsExpanded(entity);
                 var isParentExpanded = entity.Parent != null && hierarchyChangeSystem.IsExpanded(entity.Parent);
+                var isNothingOrHoveredEntitySelected = selectionState.PrimarySelectedEntity == null || selectionState.PrimarySelectedEntity.Id.Equals(entity.Id);
 
                 mainPanelData.AddHierarchyItem(entity.ShownName, level, entity.Children.Any(), isExpanded, isParentExpanded, style,
                     isPrimarySelection,
@@ -216,6 +212,16 @@ namespace Assets.Scripts.Visuals
                                 () => hierarchyContextMenuSystem.AddEntityFromPreset(preset, entity.Id)));
                         }
 
+                        var placeSelectedEntityMenuItems = new List<ContextMenuItem>()
+                        {
+                            new ContextMenuTextItem("Place above", 
+                                () => hierarchyOrderSystem.PlaceAbove(entity), isNothingOrHoveredEntitySelected),
+                            new ContextMenuTextItem("Place below", 
+                                () => hierarchyOrderSystem.PlaceBelow(entity), isNothingOrHoveredEntitySelected),
+                            new ContextMenuTextItem("Place as Child", 
+                                () => hierarchyOrderSystem.PlaceAsChild(entity), isNothingOrHoveredEntitySelected)
+                        };
+
                         var belowSibling = hierarchyOrderSystem.GetBelowSibling(entity);
                         var newHierarchyOrderForDuplicatedEntity =
                             belowSibling != null ?
@@ -232,12 +238,7 @@ namespace Assets.Scripts.Visuals
                             new ContextMenuTextItem("Delete",
                                 () => commandSystem.ExecuteCommand(
                                     commandSystem.CommandFactory.CreateRemoveEntity(entity))),
-                            new ContextMenuTextItem("Place above", 
-                                () => hierarchyOrderSystem.PlaceAbove(entity)),
-                            new ContextMenuTextItem("Place below", 
-                            () => hierarchyOrderSystem.PlaceBelow(entity)),
-                            new ContextMenuTextItem("Place as Child", 
-                                () => hierarchyOrderSystem.PlaceAsChild(entity))
+                            new ContextSubmenuItem("Selected entity...", placeSelectedEntityMenuItems)
                         });
                     },
                     draggedGameObject =>


### PR DESCRIPTION
**Summary**
Allow hierarchy order to be changed without drag and drop.
Rightclicking enables drop above/below/asChild options, when an entity is selected.
Not available options are greyed out.

#864e016gr