### PR TITLE
Fixed floating entity staying when hovering over UI - #861md0k6y

### DIFF
--- a/Assets/Scripts/Interaction/AssetButtonInteraction.cs
+++ b/Assets/Scripts/Interaction/AssetButtonInteraction.cs
@@ -91,7 +91,7 @@ public class AssetButtonInteraction : MonoBehaviour, IBeginDragHandler, IDragHan
     public void OnEndDrag(PointerEventData eventData)
     {
         if (!enableDragAndDrop) return;
-        if (!inputHelperSystem.IsMouseOverScenePanel()) return;
+        if (!entityInScene) return;
 
         AddEntityToScene(mousePositionInScene);
     }
@@ -133,7 +133,6 @@ public class AssetButtonInteraction : MonoBehaviour, IBeginDragHandler, IDragHan
         {
             case AssetMetadata.AssetType.Model:
                 addEntitySystem.AddModelAssetEntityAsCommand(newEntity, assetMetadata, position);
-
                 break;
             case AssetMetadata.AssetType.Image:
                 break;


### PR DESCRIPTION
Removing the floating entity happened after checking if the current mouse position was over ui. The asset could still be inside the scene during the dragging process, but the mouse not.
Now it looks at the last position of the mouse while dragging when checking if it should replace the floating entity. 