### PR TITLE
Added code coverage bug workaround

### DIFF
--- a/Assets/Scripts/System/Systems.asmdef
+++ b/Assets/Scripts/System/Systems.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Sistems",
+    "name": "DclSystems",
     "rootNamespace": "",
     "references": [
         "GUID:ba5f34704421b214d809dfc96dc77b31",

--- a/Assets/Scripts/System/Systems.asmdef
+++ b/Assets/Scripts/System/Systems.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Systems",
+    "name": "Sistems",
     "rootNamespace": "",
     "references": [
         "GUID:ba5f34704421b214d809dfc96dc77b31",

--- a/Assets/Scripts/Tests/EditModeTests/EditModeTests.asmdef
+++ b/Assets/Scripts/Tests/EditModeTests/EditModeTests.asmdef
@@ -2,14 +2,14 @@
     "name": "EditModeTests",
     "rootNamespace": "",
     "references": [
-        "UnityEngine.TestRunner",
-        "UnityEditor.TestRunner",
-        "SceneState",
-        "Systems",
-        "EditorState",
-        "Interaction",
-        "Events",
-        "Command"
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:ba5f34704421b214d809dfc96dc77b31",
+        "GUID:8f3c0bd18dece7b478199413c9d64c9f",
+        "GUID:b7320dc7496b5b14ab96b7aeb158b775",
+        "GUID:e0946e506e3794c42a0a4080d32eea3a",
+        "GUID:b882599d087b02e4691b090e7e01ffbb",
+        "GUID:6756ec8e32f5a594081909037fcd0fc9"
     ],
     "includePlatforms": [
         "Editor"

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -6,7 +6,7 @@
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "IncludeAssemblies",
-                "value": "{\"m_Value\":\"Command,EditorState,Events,Interaction,ProjectState,SceneState,Sistems\"}"
+                "value": "{\"m_Value\":\"Command,DclSystems,EditorState,Events,Interaction,ProjectState,SceneState\"}"
             },
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",

--- a/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
+++ b/ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json
@@ -6,7 +6,7 @@
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "IncludeAssemblies",
-                "value": "{\"m_Value\":\"Command,EditorState,SceneState,Systems\"}"
+                "value": "{\"m_Value\":\"Command,EditorState,Events,Interaction,ProjectState,SceneState,Sistems\"}"
             },
             {
                 "type": "System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
@@ -21,7 +21,7 @@
             {
                 "type": "System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
                 "key": "EnableCodeCoverage",
-                "value": "{\"m_Value\":false}"
+                "value": "{\"m_Value\":true}"
             }
         ]
     }


### PR DESCRIPTION
#861m3ujc6
Code coverage does not work for assemblies, starting with "System". Renamed "Systems" to "Sistems"