### PR TITLE
Scene assets stay red, when changing a scene - #861me3f4k

### DIFF
--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -45,7 +45,7 @@ namespace Assets.Scripts.System
         {
             InterpretArgs(Environment.GetCommandLineArgs());
 
-            assetManagerSystem.CacheAllAssetMetadata();
+            // assetManagerSystem.CacheAllAssetMetadata();
 
             customComponentMarkupSystem.SetupCustomComponents();
 

--- a/Assets/Scripts/Visuals/UiAssetBrowserVisuals.cs
+++ b/Assets/Scripts/Visuals/UiAssetBrowserVisuals.cs
@@ -80,6 +80,7 @@ namespace Assets.Scripts.Visuals
         {
             editorEvents.onAssetMetadataCacheUpdatedEvent += UpdateVisuals;
             editorEvents.onUiChangedEvent += UpdateVisuals;
+            editorEvents.OnCurrentSceneChangedEvent += assetManagerSystem.CacheAllAssetMetadata;
         }
 
         private void OnDestroy()


### PR DESCRIPTION
- Added update asset browser on opening new scene
- Removed CacheAllAssetMetadata on startup
  - Was causing and error as it was doing it twice
  - Since there is no reason for it on startup I just commented it