### PR TITLE
Update behavior on scene changed event 

### DIFF
--- a/Assets/Scripts/System/StartUpSystem.cs
+++ b/Assets/Scripts/System/StartUpSystem.cs
@@ -45,7 +45,7 @@ namespace Assets.Scripts.System
         {
             InterpretArgs(Environment.GetCommandLineArgs());
 
-            // assetManagerSystem.CacheAllAssetMetadata();
+            assetManagerSystem.CacheAllAssetMetadata();
 
             customComponentMarkupSystem.SetupCustomComponents();
 

--- a/Assets/Scripts/Visuals/UiAssetBrowserVisuals.cs
+++ b/Assets/Scripts/Visuals/UiAssetBrowserVisuals.cs
@@ -77,14 +77,14 @@ namespace Assets.Scripts.Visuals
         {
             editorEvents.onAssetMetadataCacheUpdatedEvent += UpdateVisuals;
             editorEvents.onUiChangedEvent += UpdateVisuals;
-            editorEvents.OnCurrentSceneChangedEvent += assetManagerSystem.CacheAllAssetMetadata;
+            editorEvents.OnCurrentSceneChangedEvent += UpdateContent;
         }
 
         private void OnDestroy()
         {
             editorEvents.onAssetMetadataCacheUpdatedEvent -= UpdateVisuals;
             editorEvents.onUiChangedEvent -= UpdateVisuals;
-            editorEvents.OnCurrentSceneChangedEvent -= assetManagerSystem.CacheAllAssetMetadata;
+            editorEvents.OnCurrentSceneChangedEvent -= UpdateContent;
         }
 
         private void UpdateVisuals()


### PR DESCRIPTION
- Now only uploads the asset browser content
- Previously was caching all the assets data on scene changed
- Might not work with new scene asset thumbnail generator since if the user changes the scene (adds new assets or move things) the thumbnail won't be recreated and the asset browser will keep the previous thumbnail.