### PR TITLE
Fix: Selecting a scene in a component does not work

### DIFF
--- a/Assets/Scripts/Visuals/UiPromptVisuals.cs
+++ b/Assets/Scripts/Visuals/UiPromptVisuals.cs
@@ -155,7 +155,7 @@ namespace Assets.Scripts.Visuals
 
                 // Update the target component with the new asset
                 var currentSelected = scene.SelectionState.PrimarySelectedEntity;
-                var targetComponent = currentSelected.GetFirstComponentByName("GLTFShape", "GltfContainer");
+                var targetComponent = currentSelected.GetFirstComponentByName("GLTFShape", "GltfContainer", "Scene");
                 var sceneProperty = targetComponent.GetPropertyByName("scene");
                 var assetProperty = targetComponent.GetPropertyByName("asset");
                 var srcProperty = targetComponent.GetPropertyByName("src");


### PR DESCRIPTION
Fixed NullReference by including "Scene" as valid component name