### PR TITLE
Null reference when draging custom gltf from assetbrowser to scene

### DIFF
--- a/Assets/Scripts/Visuals/GltfShapeVisuals.cs
+++ b/Assets/Scripts/Visuals/GltfShapeVisuals.cs
@@ -99,6 +99,7 @@ namespace Assets.Scripts.Visuals
 
         public override void Deactivate()
         {
+            if (_currentModelObject == null) return;
             _currentModelObject.SetActive(false);
         }
 


### PR DESCRIPTION
Problem: Primitive shapes with no "GltfContainer" or "GLTFShape" were calling the "Deactivate" method from the "GltfShapeVisuals" even though the "_currentModelObject" was null. Primitive shapes should be handled in "InitializePrimitiveShapeComponent".

Fix: Checking _currentModelObject null state and return