### PR TITLE
Fix: multi select delete all/undo/redo

### DIFF
--- a/Assets/Scripts/Command/Utility/EntityUtility.cs
+++ b/Assets/Scripts/Command/Utility/EntityUtility.cs
@@ -56,10 +56,9 @@ namespace Assets.Scripts.Command.Utility
         {
             foreach (var selectedEntity in scene.SelectionState.AllSelectedEntities)
             {
-                //This is the case when primaryselectedentity == null and no secondaryselectedentities exist
                 if (selectedEntity == null)
                 {
-                    return;
+                    continue;
                 }
                 
                 var entity = scene.GetEntityById(entityId);
@@ -90,9 +89,8 @@ namespace Assets.Scripts.Command.Utility
             {
                 scene.SelectionState.PrimarySelectedEntity = null;
             }
-            
-            scene.SelectionState.AllSelectedEntities.ToList().Remove(entity);
-            scene.SelectionState.SecondarySelectedEntities.ToList().Remove(entity);
+
+            scene.SelectionState.AllSelectedEntities = scene.SelectionState.AllSelectedEntities.Where(x => x != entity);
         }
 
         public static void AddDefaultTransformComponent(DclEntity entity)

--- a/Assets/Scripts/SceneState/SelectionState.cs
+++ b/Assets/Scripts/SceneState/SelectionState.cs
@@ -11,8 +11,12 @@ namespace Assets.Scripts.SceneState
 
         public List<DclEntity> SecondarySelectedEntities { get; set; } = new List<DclEntity>();
 
-        public IEnumerable<DclEntity> AllSelectedEntities =>
-            SecondarySelectedEntities
-                .Prepend(PrimarySelectedEntity);
+        public IEnumerable<DclEntity> AllSelectedEntities
+        {
+            get =>
+                SecondarySelectedEntities
+                    .Prepend(PrimarySelectedEntity);
+            set => SecondarySelectedEntities = new List<DclEntity>();
+        }
     }
 }


### PR DESCRIPTION
Additionally fixed undo/redo action after multi deleting

RemoveEntity.cs
- instead List<Guid> use List<DclEntity> for secondarySelectedEntity references. Inside the Undo action .ToList() creates a new list object instead of changing the original list. That has been solved by using the new List type.
- depending in which order you multi-delete (eg select child as primary) GetChildrenInOrder saves duplicate entities. That has been solved by checking first if the entity already exists and doing the same for each childNode

EntityUtility.cs & SelectionState.cs
- changed return to continue to allow the loop to continue even when a selectedEntity is null. The secondarySelectedEntities were not properly removed.
- .toList() creates a new list object instead of manipulating the original list. Solved by creating a setter in SelectionState and using Where to select only the entities that does not match the to be removed one